### PR TITLE
Circle Mesh, Shader 추가, 객체 색상 지정 방식 추가

### DIFF
--- a/Engine_SOURCE/qoConstantBuffer.cpp
+++ b/Engine_SOURCE/qoConstantBuffer.cpp
@@ -3,8 +3,13 @@
 
 namespace qo::graphics
 {
-	ConstantBuffer::ConstantBuffer()
-		:mType()
+	//ConstantBuffer::ConstantBuffer()
+	//	:mType()
+	//{
+	//}
+
+	ConstantBuffer::ConstantBuffer(eCBType type)
+		: mType(type)
 	{
 	}
 

--- a/Engine_SOURCE/qoConstantBuffer.h
+++ b/Engine_SOURCE/qoConstantBuffer.h
@@ -7,7 +7,8 @@ namespace qo::graphics
 	class ConstantBuffer : public GpuBuffer
 	{
 	public:
-		ConstantBuffer();
+		//ConstantBuffer();
+		ConstantBuffer(eCBType type);
 		~ConstantBuffer();
 
 		bool Create(size_t size);

--- a/Engine_SOURCE/qoEnums.h
+++ b/Engine_SOURCE/qoEnums.h
@@ -7,6 +7,7 @@ namespace qo::enums
 		NONE = 0,
 		PLAYER,
 		GROUND,
+		BULLET,
 		MAX = 16,
 	};
 

--- a/Engine_SOURCE/qoGraphics.h
+++ b/Engine_SOURCE/qoGraphics.h
@@ -16,7 +16,8 @@
 #define CBUFFER(name, slot) static const int CB_GETBINDSLOT(name) = slot; struct alignas(16) name
 
 #define CBSLOT_TRANSFORM		0
-#define CBSLOT_GRID				1
+#define CBSLOT_ColorTest		1
+//#define CBSLOT_GRID				1
 
 namespace qo::graphics
 {
@@ -35,6 +36,7 @@ namespace qo::graphics
 	enum class eCBType
 	{
 		Transform,
+		Color_Test,
 		Test,
 		End,
 	};

--- a/Engine_SOURCE/qoLayer.cpp
+++ b/Engine_SOURCE/qoLayer.cpp
@@ -16,11 +16,6 @@ namespace qo
 
 	void Layer::Initialize()
 	{
-		//for (GameObject* gameObject : mGameObjects)
-		//{
-		//	gameObject->Initialize();
-		//}
-
 		for (size_t i = 0; i < mGameObjects.size(); i++)
 		{
 			mGameObjects[i]->Initialize();
@@ -29,11 +24,6 @@ namespace qo
 
 	void Layer::Update()
 	{
-		//for (GameObject* gameObject : mGameObjects)
-		//{
-		//	gameObject->Update();
-		//}
-
 		for (size_t i = 0; i < mGameObjects.size(); i++)
 		{
 			mGameObjects[i]->Update();
@@ -42,11 +32,6 @@ namespace qo
 
 	void Layer::LateUpdate()
 	{
-		//for (GameObject* gameObject : mGameObjects)
-		//{
-		//	gameObject->LateUpdate();
-		//}
-
 		for (size_t i = 0; i < mGameObjects.size(); i++)
 		{
 			mGameObjects[i]->LateUpdate();
@@ -72,11 +57,6 @@ namespace qo
 
 	void Layer::Render()
 	{
-		//for (GameObject* gameObject : mGameObjects)
-		//{
-		//	gameObject->Render();
-		//}
-
 		for (size_t i = 0; i < mGameObjects.size(); i++)
 		{
 			mGameObjects[i]->Render();

--- a/Engine_SOURCE/qoMeshRenderer.cpp
+++ b/Engine_SOURCE/qoMeshRenderer.cpp
@@ -19,9 +19,6 @@ namespace qo
 
 	void MeshRenderer::Update()
 	{
-		//fhwlr
-
-		//
 	}
 
 	void MeshRenderer::LateUpdate()

--- a/Engine_SOURCE/qoRenderer.cpp
+++ b/Engine_SOURCE/qoRenderer.cpp
@@ -11,6 +11,7 @@ namespace qo::renderer
 	Mesh* TriangleMesh = nullptr;
 	Mesh* RectangleMesh = nullptr;
 	Shader* shader = nullptr;
+	Shader* ColorTestShader = nullptr;
 	ConstantBuffer* constantBuffers[(UINT)graphics::eCBType::End];
 
 	void SetUpStates()
@@ -91,8 +92,11 @@ namespace qo::renderer
 		vertices.clear();
 		indexes.clear();
 
-		constantBuffers[(UINT)graphics::eCBType::Transform] = new ConstantBuffer();
+		constantBuffers[(UINT)graphics::eCBType::Transform] = new ConstantBuffer(eCBType::Transform);
 		constantBuffers[(UINT)graphics::eCBType::Transform]->Create(sizeof(TransformCB));
+
+		constantBuffers[(UINT)graphics::eCBType::Color_Test] = new ConstantBuffer(eCBType::Color_Test);
+		constantBuffers[(UINT)graphics::eCBType::Color_Test]->Create(sizeof(ColorTestCB));
 	}
 
 	void LoadShader()
@@ -121,6 +125,17 @@ namespace qo::renderer
 			shader->GetVSCode()->GetBufferPointer()
 			, shader->GetVSCode()->GetBufferSize()
 			, shader->GetInputLayoutAddressOf());
+
+
+		// Color Test Shader 쉐이더 코드 컴파일 InputLayouts은 위와 같으므로 설정안함
+		ColorTestShader->Create(eShaderStage::VS, L"TriangleVS.hlsl", "VS_Color_Test");
+		ColorTestShader->Create(eShaderStage::PS, L"TrianglePS.hlsl", "PS_Test");
+		ResourceManager::Insert(L"ColorTestShader", ColorTestShader);
+
+		GetDevice()->CreateInputLayout(InputLayouts, 2,
+			ColorTestShader->GetVSCode()->GetBufferPointer()
+			, ColorTestShader->GetVSCode()->GetBufferSize()
+			, ColorTestShader->GetInputLayoutAddressOf());
 	}
 
 	void Initialize()
@@ -128,6 +143,7 @@ namespace qo::renderer
 		TriangleMesh = new Mesh();
 		RectangleMesh = new Mesh();
 		shader = new Shader();
+		ColorTestShader = new Shader();
 
 		LoadShader();
 		SetUpStates();
@@ -139,8 +155,10 @@ namespace qo::renderer
 		delete TriangleMesh;
 		delete RectangleMesh;
 		delete shader;
+		delete ColorTestShader;
 
 		delete constantBuffers[(UINT)graphics::eCBType::Transform];
+		delete constantBuffers[(UINT)graphics::eCBType::Color_Test];
 		//triangleVertexBuffer->Release();
 		//errorBlob->Release();
 		//triangleVSBlob->Release();

--- a/Engine_SOURCE/qoRenderer.cpp
+++ b/Engine_SOURCE/qoRenderer.cpp
@@ -8,10 +8,15 @@ namespace qo::renderer
 {
 
 	D3D11_INPUT_ELEMENT_DESC InputLayouts[2];
+
 	Mesh* TriangleMesh = nullptr;
 	Mesh* RectangleMesh = nullptr;
+	Mesh* CircleMesh = nullptr;
+
 	Shader* shader = nullptr;
 	Shader* ColorTestShader = nullptr;
+	Shader* CircleShader = nullptr;
+
 	ConstantBuffer* constantBuffers[(UINT)graphics::eCBType::End];
 
 	void SetUpStates()
@@ -92,6 +97,32 @@ namespace qo::renderer
 		vertices.clear();
 		indexes.clear();
 
+		// CircleMesh Vertex Buffer
+		Vertex center = {};
+		center.pos = Vector3(0.0f, 0.0f, 0.0f);
+		center.color = Vector4(1.0f, 1.0f, 1.0f, 1.0f);
+		vertices.push_back(center);
+
+		int degree = 360;
+		float radian = XM_2PI / (float)degree;
+		float radius = 0.5f;
+
+		for (int i = 0; i < degree; ++i)
+		{
+			center.pos = Vector3(radius * cosf(radian * (float)i), radius * sinf(radian * (float)i), 0.0f);
+			center.color = Vector4(0.0f, 1.0f, 0.0f, 1.f);
+			vertices.push_back(center);
+		}
+
+		for (int i = 0; i < vertices.size() - 2; ++i)
+			indexes.push_back(i + 1);
+
+		indexes.push_back(1);
+
+		CircleMesh->CreateVertexBuffer(vertices.data(), static_cast<UINT>(vertices.size()));
+		CircleMesh->CreateIndexBuffer(indexes.data(), static_cast<UINT>(indexes.size()));
+		ResourceManager::Insert(L"CircleMesh", CircleMesh);
+
 		constantBuffers[(UINT)graphics::eCBType::Transform] = new ConstantBuffer(eCBType::Transform);
 		constantBuffers[(UINT)graphics::eCBType::Transform]->Create(sizeof(TransformCB));
 
@@ -126,7 +157,6 @@ namespace qo::renderer
 			, shader->GetVSCode()->GetBufferSize()
 			, shader->GetInputLayoutAddressOf());
 
-
 		// Color Test Shader 쉐이더 코드 컴파일 InputLayouts은 위와 같으므로 설정안함
 		ColorTestShader->Create(eShaderStage::VS, L"TriangleVS.hlsl", "VS_Color_Test");
 		ColorTestShader->Create(eShaderStage::PS, L"TrianglePS.hlsl", "PS_Test");
@@ -136,14 +166,28 @@ namespace qo::renderer
 			ColorTestShader->GetVSCode()->GetBufferPointer()
 			, ColorTestShader->GetVSCode()->GetBufferSize()
 			, ColorTestShader->GetInputLayoutAddressOf());
+
+		// Circle Shader
+		CircleShader->Create(eShaderStage::VS, L"CircleVS.hlsl", "VS");
+		CircleShader->Create(eShaderStage::PS, L"CirclePS.hlsl", "PS");
+		CircleShader->SetTopology(D3D11_PRIMITIVE_TOPOLOGY::D3D10_PRIMITIVE_TOPOLOGY_LINELIST); // TOPOLOGY LINELIST 설정
+		ResourceManager::Insert(L"CircleShader", CircleShader);
+
+		GetDevice()->CreateInputLayout(InputLayouts, 2,
+			CircleShader->GetVSCode()->GetBufferPointer()
+			, CircleShader->GetVSCode()->GetBufferSize()
+			, CircleShader->GetInputLayoutAddressOf());
 	}
 
 	void Initialize()
 	{
 		TriangleMesh = new Mesh();
 		RectangleMesh = new Mesh();
+		CircleMesh = new Mesh();
+
 		shader = new Shader();
 		ColorTestShader = new Shader();
+		CircleShader = new Shader();
 
 		LoadShader();
 		SetUpStates();
@@ -154,8 +198,11 @@ namespace qo::renderer
 	{
 		delete TriangleMesh;
 		delete RectangleMesh;
+		delete CircleMesh;
+
 		delete shader;
 		delete ColorTestShader;
+		delete CircleShader;
 
 		delete constantBuffers[(UINT)graphics::eCBType::Transform];
 		delete constantBuffers[(UINT)graphics::eCBType::Color_Test];

--- a/Engine_SOURCE/qoRenderer.h
+++ b/Engine_SOURCE/qoRenderer.h
@@ -28,11 +28,22 @@ namespace qo::renderer
 
 		Vector3 scale;
 		int padd2;
+
+		Vector4 color;
+	};
+
+	// Color Test ¿ëµµ
+	CBUFFER(ColorTestCB, CBSLOT_ColorTest)
+	{
+		Vector4 pos;
+		Vector4 scale;
+		Vector4 color;
 	};
 
 	extern Mesh* TriangleMesh;
 	extern Mesh* RectangleMesh;
 	extern Shader* shader;
+	extern Shader* ColorTestShader;
 	extern ConstantBuffer* constantBuffers[];
 
 	// Initialize the renderer

--- a/Engine_SOURCE/qoRenderer.h
+++ b/Engine_SOURCE/qoRenderer.h
@@ -42,8 +42,12 @@ namespace qo::renderer
 
 	extern Mesh* TriangleMesh;
 	extern Mesh* RectangleMesh;
+	extern Mesh* CircleMesh;
+
 	extern Shader* shader;
 	extern Shader* ColorTestShader;
+	extern Shader* CircleShader;
+
 	extern ConstantBuffer* constantBuffers[];
 
 	// Initialize the renderer

--- a/Engine_SOURCE/qoRigidbody.cpp
+++ b/Engine_SOURCE/qoRigidbody.cpp
@@ -16,8 +16,8 @@ namespace qo
 		, mCoefficient(0.002f)
 		, mbGround(false)
 	{
-		mGravity = math::Vector3(0.f, 0.3f,0.f);
-		mMaxGravity = math::Vector3(0.2f, 1.f,0.f);
+		mGravity = math::Vector3(0.f, 1.f,0.f);
+		mMaxGravity = math::Vector3(0.2f, 10.f,0.f);
 	}
 
 	Rigidbody::~Rigidbody()

--- a/Engine_SOURCE/qoShader.cpp
+++ b/Engine_SOURCE/qoShader.cpp
@@ -7,7 +7,6 @@ namespace qo::graphics
 	Shader::Shader()
 		: mTopology(D3D_PRIMITIVE_TOPOLOGY::D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST)
 	{
-		//mTopology(D3D_PRIMITIVE_TOPOLOGY::D3D11_PRIMITIVE_TOPOLOGY_LINELIST)
 	}
 
 	Shader::~Shader()

--- a/Engine_SOURCE/qoShader.h
+++ b/Engine_SOURCE/qoShader.h
@@ -15,6 +15,7 @@ namespace qo::graphics
 		void Create(const graphics::eShaderStage stage, const std::wstring& file, const std::string& funcName);
 		void Update();
 
+		void SetTopology(D3D11_PRIMITIVE_TOPOLOGY topology) { mTopology = topology; }
 
 		ID3D11InputLayout* GetInputLayout()
 		{

--- a/Engine_SOURCE/qoTransform.cpp
+++ b/Engine_SOURCE/qoTransform.cpp
@@ -8,6 +8,7 @@ namespace qo
 
 	Transform::Transform()
 		: Component(COMPONENTTYPE::TRANSFORM)
+		, mColor(math::Vector4(1.f, 1.f, 1.f, 0.f))
 	{
 
 	}
@@ -66,8 +67,7 @@ namespace qo
 
 			data.pos = math::Vector4(temp.x, temp.y, temp.z, 0.f);
 			data.scale = math::Vector4(mScale.x, mScale.y, mScale.z, 0.f);
-			// 이 Color 값을 클래스 or 객체 마다 멤버변수로 보유하고 셋팅해주는 방식
-			data.color = math::Vector4(1.f, 1.f, 1.f, 0.f);
+			data.color = mColor;
 			Register1Cb->SetData(&data);
 
 			Register1Cb->Bind(graphics::eShaderStage::VS);

--- a/Engine_SOURCE/qoTransform.cpp
+++ b/Engine_SOURCE/qoTransform.cpp
@@ -34,20 +34,43 @@ namespace qo
 
 	void Transform::SetConstantBuffer()
 	{
-		ConstantBuffer* cb = renderer::constantBuffers[(UINT)graphics::eCBType::Transform];
+		// 레지스터 0번 상수 버퍼 셋팅
+		{
+			ConstantBuffer* Register0Cb = renderer::constantBuffers[(UINT)graphics::eCBType::Transform];
 
-		renderer::TransformCB data = {};
-		math::Vector3 temp;
-		temp.x = mPosition.x;
-		temp.y = mPosition.y;
-		temp.z = mPosition.z;
-		temp = Camera::CaculatePos(temp);
+			renderer::TransformCB data = {};
+			math::Vector3 temp;
+			temp.x = mPosition.x;
+			temp.y = mPosition.y;
+			temp.z = mPosition.z;
+			temp = Camera::CaculatePos(temp);
 
-		data.pos = temp;
-		data.scale = mScale;
-		cb->SetData(&data);
+			data.pos = temp;
+			data.scale = mScale;
+			Register0Cb->SetData(&data);
 
-		cb->Bind(graphics::eShaderStage::VS);
+			Register0Cb->Bind(graphics::eShaderStage::VS);
+		}
+
+
+		// 레지스터 1번 상수 버퍼 셋팅
+		{
+			ConstantBuffer* Register1Cb = renderer::constantBuffers[(UINT)graphics::eCBType::Color_Test];
+
+			renderer::ColorTestCB data = {};
+			math::Vector3 temp;
+			temp.x = mPosition.x;
+			temp.y = mPosition.y;
+			temp.z = mPosition.z;
+			temp = Camera::CaculatePos(temp);
+
+			data.pos = math::Vector4(temp.x, temp.y, temp.z, 0.f);
+			data.scale = math::Vector4(mScale.x, mScale.y, mScale.z, 0.f);
+			// 이 Color 값을 클래스 or 객체 마다 멤버변수로 보유하고 셋팅해주는 방식
+			data.color = math::Vector4(1.f, 1.f, 1.f, 0.f);
+			Register1Cb->SetData(&data);
+
+			Register1Cb->Bind(graphics::eShaderStage::VS);
+		}		
 	}
-
 }

--- a/Engine_SOURCE/qoTransform.h
+++ b/Engine_SOURCE/qoTransform.h
@@ -28,9 +28,15 @@ namespace qo
 		Vector3 GetRotation() { return mRotation; }
 		Vector3 GetScale() { return mScale; }
 
+
+		void SetColor(math::Vector4 color) { mColor = color; }
+
 	private:
 		Vector3 mPosition;
 		Vector3 mRotation;
 		Vector3 mScale;
+
+		// 상수버퍼에 전달해줄 Color 값
+		Vector4 mColor;
 	};
 }

--- a/Engine_Windows/Engine_Windows.vcxproj
+++ b/Engine_Windows/Engine_Windows.vcxproj
@@ -33,6 +33,9 @@
     <ClInclude Include="qoPlayerScript.h" />
     <ClInclude Include="qoPlayScene.h" />
     <ClInclude Include="qoLoadScene.h" />
+    <ClInclude Include="qoSuperpositionBullet.h" />
+    <ClInclude Include="qoSuperpositionGun.h" />
+    <ClInclude Include="qoSuperpositionGunScript.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="qoBullet.cpp" />
@@ -48,6 +51,9 @@
     <ClCompile Include="qoPlayer.cpp" />
     <ClCompile Include="qoPlayerScript.cpp" />
     <ClCompile Include="qoPlayScene.cpp" />
+    <ClCompile Include="qoSuperpositionBullet.cpp" />
+    <ClCompile Include="qoSuperpositionGun.cpp" />
+    <ClCompile Include="qoSuperpositionGunScript.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>

--- a/Engine_Windows/Engine_Windows.vcxproj.filters
+++ b/Engine_Windows/Engine_Windows.vcxproj.filters
@@ -37,6 +37,15 @@
     <Filter Include="GameObjects\Ground">
       <UniqueIdentifier>{3caf6517-03eb-4aab-b2d2-5a90f0c0fb86}</UniqueIdentifier>
     </Filter>
+    <Filter Include="GameObjects\Gun\SuperpositionGun">
+      <UniqueIdentifier>{b262c602-c1b2-4b34-8740-a45e7ba63fd8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Scripts\Gun\Superposition">
+      <UniqueIdentifier>{5bb61431-bab3-4a75-bbeb-99a9a50cbb1b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="GameObjects\Bullet\SuperpositionBullet">
+      <UniqueIdentifier>{859634ca-0bce-4995-8a77-9a1f93ec8422}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="qoPlayScene.cpp">
@@ -57,9 +66,6 @@
     <ClCompile Include="qoGun.cpp">
       <Filter>GameObjects\Gun</Filter>
     </ClCompile>
-    <ClCompile Include="qoGunScript.cpp">
-      <Filter>Scripts\Gun</Filter>
-    </ClCompile>
     <ClCompile Include="qoEnemy.cpp">
       <Filter>GameObjects\Enemy</Filter>
     </ClCompile>
@@ -77,6 +83,18 @@
     </ClCompile>
     <ClCompile Include="qoGround.cpp">
       <Filter>GameObjects\Ground</Filter>
+    </ClCompile>
+    <ClCompile Include="qoSuperpositionGun.cpp">
+      <Filter>GameObjects\Gun\SuperpositionGun</Filter>
+    </ClCompile>
+    <ClCompile Include="qoGunScript.cpp">
+      <Filter>Scripts\Gun</Filter>
+    </ClCompile>
+    <ClCompile Include="qoSuperpositionGunScript.cpp">
+      <Filter>Scripts\Gun\Superposition</Filter>
+    </ClCompile>
+    <ClCompile Include="qoSuperpositionBullet.cpp">
+      <Filter>GameObjects\Bullet\SuperpositionBullet</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -119,6 +137,15 @@
     </ClInclude>
     <ClInclude Include="qoGround.h">
       <Filter>GameObjects\Ground</Filter>
+    </ClInclude>
+    <ClInclude Include="qoSuperpositionGun.h">
+      <Filter>GameObjects\Gun\SuperpositionGun</Filter>
+    </ClInclude>
+    <ClInclude Include="qoSuperpositionGunScript.h">
+      <Filter>Scripts\Gun\Superposition</Filter>
+    </ClInclude>
+    <ClInclude Include="qoSuperpositionBullet.h">
+      <Filter>GameObjects\Bullet\SuperpositionBullet</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Engine_Windows/qoBullet.cpp
+++ b/Engine_Windows/qoBullet.cpp
@@ -10,24 +10,4 @@ namespace qo
 	Bullet::~Bullet()
 	{
 	}
-
-	void Bullet::Initialize()
-	{
-		GameObject::Initialize();
-	}
-
-	void Bullet::Update()
-	{
-		GameObject::Update();
-	}
-
-	void Bullet::LateUpdate()
-	{
-		GameObject::LateUpdate();
-	}
-
-	void Bullet::Render()
-	{
-		GameObject::Render();
-	}
 }

--- a/Engine_Windows/qoBullet.h
+++ b/Engine_Windows/qoBullet.h
@@ -5,15 +5,20 @@ namespace qo
 {
     class Bullet : public GameObject
     {
-		friend class BulletScript;
 	public:
 		Bullet(Vector3 Dir);
 		virtual ~Bullet();
 
-		virtual void Initialize() override;
-		virtual void Update() override;
-		virtual void LateUpdate() override;
-		virtual void Render() override;
+		virtual void Initialize() = 0;
+		virtual void Update() = 0;
+		virtual void LateUpdate() = 0;
+		virtual void Render() = 0;
+
+		virtual void OnCollisionEnter(class Collider* other) = 0;
+		virtual void OnCollisionStay(class Collider* other) = 0;
+		virtual void OnCollisionExit(class Collider* other) = 0;
+
+		Vector3 GetDirection() const { return mDir; }
 
 	private:
 		Vector3 mDir;

--- a/Engine_Windows/qoBulletScript.cpp
+++ b/Engine_Windows/qoBulletScript.cpp
@@ -21,19 +21,19 @@ namespace qo
 	{
 		Bullet* bullet = dynamic_cast<Bullet*>(GetOwner());
 		
+		if (bullet == nullptr)
+			return;
+		
 		// Bullet이 갖고있는 방향으로 초당 2.f 의 속도로 이동
-		if (bullet != nullptr)
-		{
-			Transform* tr = bullet->GetComponent<Transform>();
-			Vector3 dir = bullet->GetDirection();
+		Transform* tr = bullet->GetComponent<Transform>();
+		Vector3 dir = bullet->GetDirection();
 
-			Vector3 pos = tr->GetPosition();
+		Vector3 pos = tr->GetPosition();
 
-			dir.Normalize();
+		dir.Normalize();
 
-			pos += dir * 2.f * Time::DeltaTime();
-			tr->SetPosition(pos);
-		}
+		pos += dir * 2.f * Time::DeltaTime();
+		tr->SetPosition(pos);		
 	}
 
 	void BulletScript::LateUpdate()

--- a/Engine_Windows/qoBulletScript.cpp
+++ b/Engine_Windows/qoBulletScript.cpp
@@ -21,7 +21,7 @@ namespace qo
 	{
 		Bullet* bullet = dynamic_cast<Bullet*>(GetOwner());
 		
-		// Bullet이 갖고있는 방향으로 초당 5.f 의 속도로 이동
+		// Bullet이 갖고있는 방향으로 초당 1.f 의 속도로 이동
 		if (bullet != nullptr)
 		{
 			Transform* tr = bullet->GetComponent<Transform>();
@@ -31,7 +31,7 @@ namespace qo
 
 			dir.Normalize();
 
-			pos += dir * 5.f * Time::DeltaTime();
+			pos += dir * 1.f * Time::DeltaTime();
 			tr->SetPosition(pos);
 		}
 	}

--- a/Engine_Windows/qoBulletScript.cpp
+++ b/Engine_Windows/qoBulletScript.cpp
@@ -21,17 +21,17 @@ namespace qo
 	{
 		Bullet* bullet = dynamic_cast<Bullet*>(GetOwner());
 		
-		// Bullet이 갖고있는 방향으로 초당 1.f 의 속도로 이동
+		// Bullet이 갖고있는 방향으로 초당 2.f 의 속도로 이동
 		if (bullet != nullptr)
 		{
 			Transform* tr = bullet->GetComponent<Transform>();
-			Vector3 dir = bullet->mDir;
+			Vector3 dir = bullet->GetDirection();
 
 			Vector3 pos = tr->GetPosition();
 
 			dir.Normalize();
 
-			pos += dir * 1.f * Time::DeltaTime();
+			pos += dir * 2.f * Time::DeltaTime();
 			tr->SetPosition(pos);
 		}
 	}

--- a/Engine_Windows/qoGun.cpp
+++ b/Engine_Windows/qoGun.cpp
@@ -1,10 +1,10 @@
 #include "qoGun.h"
 
-
 namespace qo
 {
-	Gun::Gun(Player* owner, UINT bulletCount)
-		: mPlayer(owner)
+	Gun::Gun(eGunType type, Player* owner, UINT bulletCount)
+		: mGunType(type)
+		, mPlayer(owner)
 		, mBulletCount(bulletCount)
 	{
 	}
@@ -13,23 +13,13 @@ namespace qo
 	{
 	}
 
-	void Gun::Initialize()
+	bool Gun::BulletConsumption(UINT amount)
 	{
-		GameObject::Initialize();
-	}
+		// 소모되는 양이 남아있는 탄알보다 많다면 실패처리
+		if(mBulletCount - amount < 0)
+			return false;
 
-	void Gun::Update()
-	{
-		GameObject::Update();
-	}
-
-	void Gun::LateUpdate()
-	{
-		GameObject::LateUpdate();
-	}
-
-	void Gun::Render()
-	{
-		GameObject::Render();
+		mBulletCount -= amount;
+		return true;
 	}
 }

--- a/Engine_Windows/qoGun.h
+++ b/Engine_Windows/qoGun.h
@@ -1,24 +1,30 @@
 #pragma once
 #include "qoGameObject.h"
+#include "qoPlayer.h"
 
 namespace qo
 {
 	class Player;
 	class Gun : public GameObject
 	{
-		friend class GunScript;
 	public:
-		Gun(Player* owner, UINT bulletCount);
+		Gun(eGunType type, Player* owner, UINT bulletCount);
 		virtual ~Gun();
 
-		virtual void Initialize() override;
-		virtual void Update() override;
-		virtual void LateUpdate() override;
-		virtual void Render() override;
+		virtual void Initialize() = 0;
+		virtual void Update() = 0;
+		virtual void LateUpdate()  = 0;
+		virtual void Render() = 0;
+
+		UINT GetBulletCount() const { return mBulletCount; }
+		bool BulletConsumption(UINT amount);
+
+		Player* GetPlayer() const { return mPlayer; }
 
 	private:
-		Player* mPlayer;
-		UINT	mBulletCount;
+		eGunType	mGunType;
+		Player*		mPlayer;
+		UINT		mBulletCount;
 	};
 }
 

--- a/Engine_Windows/qoGunScript.cpp
+++ b/Engine_Windows/qoGunScript.cpp
@@ -36,7 +36,9 @@ namespace qo
 		Transform* GunTransform = owner->GetComponent<Transform>();		
 		Transform* PlayerTransform = owner->mPlayer->GetComponent<Transform>();
 
-		GunTransform->SetPosition(PlayerTransform->GetPosition());
+		Vector3 GunPos = PlayerTransform->GetPosition() + Vector3(0.2f, 0.f, 0.f);
+
+		GunTransform->SetPosition(GunPos);
 
 		// ÃÑ¾Ë ¹ß»ç
 		if (Input::GetKeyState(KEY_CODE::LBTN) == KEY_STATE::DOWN)
@@ -93,8 +95,8 @@ namespace qo
 			tr->SetScale(Vector3(0.1f, 0.1f, 0.1f));
 
 			MeshRenderer* meshRenderer = bullet->AddComponent<MeshRenderer>();
-			meshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"RectangleMesh"));
-			meshRenderer->SetShader(ResourceManager::Find<Shader>(L"TriangleShader"));
+			meshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"CircleMesh"));
+			meshRenderer->SetShader(ResourceManager::Find<Shader>(L"CircleShader"));
 
 			bullet->AddComponent<BulletScript>();
 

--- a/Engine_Windows/qoGunScript.cpp
+++ b/Engine_Windows/qoGunScript.cpp
@@ -1,18 +1,6 @@
 #include "qoGunScript.h"
 #include "qoGun.h"
-#include "qoBullet.h"
-#include "qoInput.h"
 #include "qoTransform.h"
-#include "qoPlayer.h"
-#include "qoBullet.h"
-#include "qoApplication.h"
-#include "qoMeshRenderer.h"
-#include "qoResourceManager.h"
-#include "qoSceneManager.h"
-#include "qoBulletScript.h"
-
-extern qo::Application application;
-
 
 namespace qo
 {
@@ -34,21 +22,11 @@ namespace qo
 		Gun* owner = dynamic_cast<Gun*>(GetOwner());
 
 		Transform* GunTransform = owner->GetComponent<Transform>();		
-		Transform* PlayerTransform = owner->mPlayer->GetComponent<Transform>();
+		Transform* PlayerTransform = owner->GetPlayer()->GetComponent<Transform>();
 
 		Vector3 GunPos = PlayerTransform->GetPosition() + Vector3(0.2f, 0.f, 0.f);
 
 		GunTransform->SetPosition(GunPos);
-
-		// 총알 발사
-		if (Input::GetKeyState(KEY_CODE::LBTN) == KEY_STATE::DOWN)
-		{
-			if (owner->mBulletCount > 0)
-			{
-				--owner->mBulletCount;				
-				Shoot();
-			}
-		}
 	}
 
 	void GunScript::LateUpdate()
@@ -57,52 +35,5 @@ namespace qo
 
 	void GunScript::Render()
 	{
-	}
-
-	void GunScript::Shoot()
-	{
-		Gun* owner = dynamic_cast<Gun*>(GetOwner());
-		
-		if (owner != nullptr)
-		{
-			// ==============================================
-			// 총알 방향 결정 Gun 위치 → 현재 마우스 위치로 발사
-			// ==============================================
-			Vector2 mousePos = Input::GetMousPosition();
-			Vector3 GunPos = owner->GetComponent<Transform>()->GetPosition();
-
-			// 윈도우 좌표계 → 왼손 좌표계 기준 변환
-			GunPos.x += application.GetWidth() / 2.f;
-			GunPos.y += application.GetHeight() / 2.f;
-
-			// Gun 위치 → 현재 마우스 위치
-			Vector3 Dir = Vector3(0.f, 0.f, 0.f);
-			Dir.x = mousePos.x - GunPos.x;
-			Dir.y = mousePos.y - GunPos.y;
-			Dir.y *= -1.f; // Window 좌표계 → 왼손 좌표계 Y 방향 전환
-
-
-
-			// Gun 위치 재설정
-			GunPos = owner->GetComponent<Transform>()->GetPosition();
-
-			// ================================================
-			// 총알 생성
-			// ================================================
-			Bullet* bullet = new Bullet(Dir);
-			Transform* tr = bullet->AddComponent<Transform>();
-			tr->SetPosition(GunPos); // 총알 시작위치는 총위치로 설정
-			tr->SetScale(Vector3(0.1f, 0.1f, 0.1f));
-
-			MeshRenderer* meshRenderer = bullet->AddComponent<MeshRenderer>();
-			meshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"CircleMesh"));
-			meshRenderer->SetShader(ResourceManager::Find<Shader>(L"CircleShader"));
-
-			bullet->AddComponent<BulletScript>();
-
-			bullet->Initialize();
-
-			SceneManager::GetActiveScene()->AddGameObject(bullet, LAYER::NONE);
-		}	
 	}
 }

--- a/Engine_Windows/qoGunScript.cpp
+++ b/Engine_Windows/qoGunScript.cpp
@@ -21,12 +21,21 @@ namespace qo
 		// Gun의 위치를 플레이어 위치로 설정한다.
 		Gun* owner = dynamic_cast<Gun*>(GetOwner());
 
+		if (owner == nullptr)
+			return;
+
 		Transform* GunTransform = owner->GetComponent<Transform>();		
 		Transform* PlayerTransform = owner->GetPlayer()->GetComponent<Transform>();
 
 		Vector3 GunPos = PlayerTransform->GetPosition() + Vector3(0.2f, 0.f, 0.f);
 
 		GunTransform->SetPosition(GunPos);
+
+
+		if (owner->GetBulletCount() <= 0)
+		{
+			GunTransform->SetColor(Vector4(1.f, 0.f, 0.f, 0.f));
+		}
 	}
 
 	void GunScript::LateUpdate()

--- a/Engine_Windows/qoPlayScene.cpp
+++ b/Engine_Windows/qoPlayScene.cpp
@@ -44,8 +44,8 @@ namespace qo
 		
 		player->AddComponent<PlayerScript>();
 
-		// 총 하나 생성
-		player->AddGun();
+		// 총 생성
+		player->AddGun(eGunType::Superposition);
 
 		player->Initialize();
 
@@ -67,6 +67,24 @@ namespace qo
 		AddGameObject(ground, LAYER::GROUND);
 
 		CollisionManager::CollisionLayerCheck(LAYER::PLAYER, LAYER::GROUND, TRUE);
+
+		// 벽 오브젝트 생성
+		Ground* Wall = new Ground();
+		Transform* WallTransform = Wall->AddComponent<Transform>();
+		WallTransform->SetPosition(Vector3(0.5f, 0.0f, 0.0f));
+		WallTransform->SetScale(Vector3(0.3f, 1.f, 0.0f));
+		WallTransform->SetColor(Vector4(0.3f, 0.3f, 0.3f, 0.f));
+
+		MeshRenderer* WallMeshRenderer = Wall->AddComponent<MeshRenderer>();
+		WallMeshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"RectangleMesh"));
+		WallMeshRenderer->SetShader(ResourceManager::Find<Shader>(L"ColorTestShader"));
+
+		Collider* WallCollider = Wall->AddComponent<Collider>();
+		WallCollider->SetScale(Vector3(0.3f, 1.f, 0.0f));
+
+		AddGameObject(Wall, LAYER::GROUND);
+
+		CollisionManager::CollisionLayerCheck(LAYER::BULLET, LAYER::GROUND, TRUE);
 	}
 
 	void PlayScene::Update()

--- a/Engine_Windows/qoPlayScene.cpp
+++ b/Engine_Windows/qoPlayScene.cpp
@@ -30,11 +30,12 @@ namespace qo
 		Player* player = new Player();
 		Transform* PlayerTransform = player->AddComponent<Transform>();
 		PlayerTransform->SetPosition(Vector3(0.0f, 0.0f, 0.0f));
-		PlayerTransform->SetScale(Vector3(0.3f, 0.3f, 0.f));
+		PlayerTransform->SetScale(Vector3(0.1f, 0.3f, 0.f));
+		PlayerTransform->SetColor(Vector4(0.f, 1.f, 0.f, 0.f));
 
 		MeshRenderer* PlayerMeshRenderer = player->AddComponent<MeshRenderer>();
 		PlayerMeshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"RectangleMesh"));
-		PlayerMeshRenderer->SetShader(ResourceManager::Find<Shader>(L"TriangleShader"));
+		PlayerMeshRenderer->SetShader(ResourceManager::Find<Shader>(L"ColorTestShader"));	
 
 		Collider* PlayerCollider = player->AddComponent<Collider>();
 		PlayerCollider->SetScale(Vector3(0.3f, 0.3f, 0.f));
@@ -54,6 +55,7 @@ namespace qo
 		Transform* GroundTransform = ground->AddComponent<Transform>();
 		GroundTransform->SetPosition(Vector3(0.0f, -0.5f, 0.0f));
 		GroundTransform->SetScale(Vector3(1.f, 0.3f, 0.0f));
+		GroundTransform->SetColor(Vector4(0.5f, 0.5f, 0.5f, 0.f));
 
 		MeshRenderer* GroundMeshRenderer = ground->AddComponent<MeshRenderer>();
 		GroundMeshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"RectangleMesh"));

--- a/Engine_Windows/qoPlayScene.cpp
+++ b/Engine_Windows/qoPlayScene.cpp
@@ -57,7 +57,7 @@ namespace qo
 
 		MeshRenderer* GroundMeshRenderer = ground->AddComponent<MeshRenderer>();
 		GroundMeshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"RectangleMesh"));
-		GroundMeshRenderer->SetShader(ResourceManager::Find<Shader>(L"TriangleShader"));
+		GroundMeshRenderer->SetShader(ResourceManager::Find<Shader>(L"ColorTestShader")); 
 
 		Collider* GroundCollider = ground->AddComponent<Collider>();
 		GroundCollider->SetScale(Vector3(1.f, 0.25f, 0.f));

--- a/Engine_Windows/qoPlayer.cpp
+++ b/Engine_Windows/qoPlayer.cpp
@@ -81,14 +81,17 @@ namespace qo
 		// ÃÑ °´Ã¼ »ý¼º
 		// ============
 		Gun* gun = new Gun(this, 50);
+		Vector3 GunPos = PlayerPos + Vector3(0.1f, 0.f,0.f);
+
 
 		Transform* GunTransform = gun->AddComponent<Transform>();
-		GunTransform->SetPosition(PlayerPos);
-		GunTransform->SetScale(Vector3(0.3f, 0.3f, 0.3f));
+		GunTransform->SetPosition(GunPos);
+		GunTransform->SetScale(Vector3(0.1f, 0.1f, 0.f));
+		GunTransform->SetColor(Vector4(0.f, 0.f, 0.f, 0.f));
 
 		MeshRenderer* meshRenderer = gun->AddComponent<MeshRenderer>();
 		meshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"RectangleMesh"));
-		meshRenderer->SetShader(ResourceManager::Find<Shader>(L"TriangleShader"));
+		meshRenderer->SetShader(ResourceManager::Find<Shader>(L"ColorTestShader"));
 
 		gun->AddComponent<GunScript>();
 		

--- a/Engine_Windows/qoPlayer.cpp
+++ b/Engine_Windows/qoPlayer.cpp
@@ -1,9 +1,11 @@
 #include "qoPlayer.h"
 #include "qoGun.h"
 #include "qoGunScript.h"
+#include "qoSuperpositionGunScript.h"
 #include "qoTransform.h"
 #include "qoMeshRenderer.h"
 #include "qoResourceManager.h"
+#include "qoSuperpositionGun.h"
 
 namespace qo
 {
@@ -67,37 +69,48 @@ namespace qo
 		}
 	}
 
-	void Player::TakeHit(int DamageAmount, math::Vector3 HitDir)
-	{
-	}
-
-	void Player::AddGun()
+	void Player::AddGun(eGunType type)
 	{
 		// ÇÃ·¹ÀÌ¾î °´Ã¼ Á¤º¸
 		Transform* PlayerTransform = GetComponent<Transform>();
 		Vector3 PlayerPos = PlayerTransform->GetPosition();
 
-		// ============
+		// ================================
 		// ÃÑ °´Ã¼ »ý¼º
-		// ============
-		Gun* gun = new Gun(this, 50);
-		Vector3 GunPos = PlayerPos + Vector3(0.1f, 0.f,0.f);
+		// ================================
+		if (type == eGunType::Superposition)
+		{
+			SuperpositionGun* gun = new SuperpositionGun(type, this, 50);
+			Vector3 GunPos = PlayerPos + Vector3(0.2f, 0.f, 0.f);
 
+			Transform* GunTransform = gun->AddComponent<Transform>();
+			GunTransform->SetPosition(GunPos);
+			GunTransform->SetScale(Vector3(0.1f, 0.1f, 0.f));
+			GunTransform->SetColor(Vector4(0.f, 0.f, 0.f, 0.f));
 
-		Transform* GunTransform = gun->AddComponent<Transform>();
-		GunTransform->SetPosition(GunPos);
-		GunTransform->SetScale(Vector3(0.1f, 0.1f, 0.f));
-		GunTransform->SetColor(Vector4(0.f, 0.f, 0.f, 0.f));
+			MeshRenderer* meshRenderer = gun->AddComponent<MeshRenderer>();
+			meshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"RectangleMesh"));
+			meshRenderer->SetShader(ResourceManager::Find<Shader>(L"ColorTestShader"));
 
-		MeshRenderer* meshRenderer = gun->AddComponent<MeshRenderer>();
-		meshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"RectangleMesh"));
-		meshRenderer->SetShader(ResourceManager::Find<Shader>(L"ColorTestShader"));
+			gun->AddComponent<GunScript>();
+			gun->AddComponent<SuperpositionGunScript>();
 
-		gun->AddComponent<GunScript>();
-		
-		gun->Initialize();
+			gun->Initialize();
 
-		mGuns.push_back(gun);
-		mActiveGun = gun;		
+			mGuns.push_back(gun);
+			mActiveGun = gun;
+		}
+		else if(type == eGunType::Entanglement)
+		{
+
+		}
+		else if (type == eGunType::Teleportation)
+		{
+
+		}
+	}
+
+	void Player::TakeHit(int DamageAmount, math::Vector3 HitDir)
+	{
 	}
 }

--- a/Engine_Windows/qoPlayer.cpp
+++ b/Engine_Windows/qoPlayer.cpp
@@ -80,7 +80,7 @@ namespace qo
 		// ================================
 		if (type == eGunType::Superposition)
 		{
-			SuperpositionGun* gun = new SuperpositionGun(type, this, 50);
+			SuperpositionGun* gun = new SuperpositionGun(type, this, 10);
 			Vector3 GunPos = PlayerPos + Vector3(0.2f, 0.f, 0.f);
 
 			Transform* GunTransform = gun->AddComponent<Transform>();

--- a/Engine_Windows/qoPlayer.h
+++ b/Engine_Windows/qoPlayer.h
@@ -12,6 +12,13 @@ namespace qo
         Dead,
     };
 
+    enum class eGunType
+    {
+        Superposition,
+        Entanglement,
+        Teleportation,
+    };
+
     class Gun;
     class Player : public GameObject
     {
@@ -25,7 +32,7 @@ namespace qo
         virtual void LateUpdate() override;
         virtual void Render() override;
 
-        void AddGun();
+        void AddGun(eGunType type);
         virtual void TakeHit(int DamageAmount, math::Vector3 HitDir = Vector3::Zero);
 
     private:

--- a/Engine_Windows/qoSuperpositionBullet.cpp
+++ b/Engine_Windows/qoSuperpositionBullet.cpp
@@ -1,0 +1,54 @@
+#include "qoSuperpositionBullet.h"
+#include "qoGameObject.h"
+#include "qoGround.h"
+#include "qoCollider.h"
+
+namespace qo
+{
+	SuperpositionBullet::SuperpositionBullet(Vector3 Dir)
+		: Bullet(Dir)
+	{
+	}
+
+	SuperpositionBullet::~SuperpositionBullet()
+	{
+	}
+
+	void SuperpositionBullet::Initialize()
+	{
+		GameObject::Initialize();
+	}
+
+	void SuperpositionBullet::Update()
+	{
+		GameObject::Update();
+	}
+
+	void SuperpositionBullet::LateUpdate()
+	{
+		GameObject::LateUpdate();
+	}
+
+	void SuperpositionBullet::Render()
+	{
+		GameObject::Render();
+	}
+
+	void SuperpositionBullet::OnCollisionEnter(Collider* other)
+	{
+		Ground* Test = dynamic_cast<Ground*>(other->GetOwner());
+
+		if (Test == nullptr)
+			return;
+
+		Destroy(this);
+	}
+
+	void SuperpositionBullet::OnCollisionStay(Collider* other)
+	{
+	}
+
+	void SuperpositionBullet::OnCollisionExit(Collider* other)
+	{
+	}
+}

--- a/Engine_Windows/qoSuperpositionBullet.h
+++ b/Engine_Windows/qoSuperpositionBullet.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "qoBullet.h"
+
+namespace qo
+{
+	class SuperpositionBullet : public Bullet
+	{
+	public:
+		SuperpositionBullet(Vector3 Dir);
+		virtual ~SuperpositionBullet();
+
+		virtual void Initialize() override;
+		virtual void Update() override;
+		virtual void LateUpdate() override;
+		virtual void Render() override;
+
+		virtual void OnCollisionEnter(class Collider* other) override;
+		virtual void OnCollisionStay(class Collider* other) override;
+		virtual void OnCollisionExit(class Collider* other) override;
+	};
+}
+

--- a/Engine_Windows/qoSuperpositionGun.cpp
+++ b/Engine_Windows/qoSuperpositionGun.cpp
@@ -1,0 +1,35 @@
+#include "qoSuperpositionGun.h"
+#include "qoGameObject.h"
+#include "qoPlayer.h"
+
+namespace qo
+{
+	SuperpositionGun::SuperpositionGun(eGunType type, Player* owner, UINT bulletCount)
+		: Gun(type, owner, bulletCount)
+	{
+	}
+
+	SuperpositionGun::~SuperpositionGun()
+	{
+	}
+
+	void SuperpositionGun::Initialize()
+	{
+		GameObject::Initialize();
+	}
+
+	void SuperpositionGun::Update()
+	{
+		GameObject::Update();
+	}
+
+	void SuperpositionGun::LateUpdate()
+	{
+		GameObject::LateUpdate();
+	}
+
+	void SuperpositionGun::Render()
+	{
+		GameObject::Render();
+	}
+}

--- a/Engine_Windows/qoSuperpositionGun.h
+++ b/Engine_Windows/qoSuperpositionGun.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "qoGun.h"
+
+namespace qo
+{
+	class SuperpositionGun : public Gun
+	{
+	public:
+		SuperpositionGun(eGunType type, Player* owner, UINT bulletCount);
+		virtual ~SuperpositionGun();
+
+		virtual void Initialize() override;
+		virtual void Update() override;
+		virtual void LateUpdate() override;
+		virtual void Render() override;
+	};
+}
+

--- a/Engine_Windows/qoSuperpositionGunScript.cpp
+++ b/Engine_Windows/qoSuperpositionGunScript.cpp
@@ -1,0 +1,106 @@
+#include "qoSuperpositionGunScript.h"
+#include "qoInput.h"
+#include "qoApplication.h"
+#include "qoGun.h"
+#include "qoTransform.h"
+#include "qoSuperpositionBullet.h"
+#include "qoMeshRenderer.h"
+#include "qoSceneManager.h"
+#include "qoResourceManager.h"
+#include "qoBulletScript.h"
+#include "qoCollider.h"
+
+extern qo::Application application;
+
+namespace qo
+{
+	SuperpositionGunScript::SuperpositionGunScript()
+	{
+	}
+
+	SuperpositionGunScript::~SuperpositionGunScript()
+	{
+	}
+
+	void SuperpositionGunScript::Initialize()
+	{
+	}
+
+	void SuperpositionGunScript::Update()
+	{
+		Gun* owner = dynamic_cast<Gun*>(GetOwner());
+
+		if (owner == nullptr)
+			return;
+		
+		// 총알 발사
+		if (Input::GetKeyState(KEY_CODE::LBTN) == KEY_STATE::DOWN)
+		{
+			if (owner->GetBulletCount() > 0)
+			{
+				if (owner->BulletConsumption(1))
+				{
+					Shoot();
+				}
+			}
+		}		
+	}
+
+	void SuperpositionGunScript::LateUpdate()
+	{
+	}
+
+	void SuperpositionGunScript::Render()
+	{
+	}
+
+	void SuperpositionGunScript::Shoot()
+	{
+		Gun* owner = dynamic_cast<Gun*>(GetOwner());
+
+		if (owner != nullptr)
+		{
+			// ==============================================
+			// 총알 방향 결정 Gun 위치 → 현재 마우스 위치로 발사
+			// ==============================================
+			Vector2 mousePos = Input::GetMousPosition();
+			Vector3 GunPos = owner->GetComponent<Transform>()->GetPosition();
+
+			// 윈도우 좌표계 → 왼손 좌표계 기준 변환
+			GunPos.x += application.GetWidth() / 2.f;
+			GunPos.y += application.GetHeight() / 2.f;
+
+			// Gun 위치 → 현재 마우스 위치
+			Vector3 Dir = Vector3(0.f, 0.f, 0.f);
+			Dir.x = mousePos.x - GunPos.x;
+			Dir.y = mousePos.y - GunPos.y;
+			Dir.y *= -1.f; // Window 좌표계 → 왼손 좌표계 Y 방향 전환
+
+
+
+			// Gun 위치 재설정
+			GunPos = owner->GetComponent<Transform>()->GetPosition();
+
+			// ================================================
+			// 총알 생성
+			// ================================================
+			SuperpositionBullet* bullet = new SuperpositionBullet(Dir);
+			Transform* tr = bullet->AddComponent<Transform>();
+			tr->SetPosition(GunPos); // 총알 시작위치는 총위치로 설정
+			tr->SetScale(Vector3(0.1f, 0.1f, 0.1f));
+
+			MeshRenderer* meshRenderer = bullet->AddComponent<MeshRenderer>();
+			meshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"CircleMesh"));
+			meshRenderer->SetShader(ResourceManager::Find<Shader>(L"CircleShader"));
+
+			Collider* col = bullet->AddComponent<Collider>();
+			col->SetScale(Vector3(0.1f, 0.1f, 0.1f));
+
+			bullet->AddComponent<BulletScript>();
+
+			bullet->Initialize();
+
+			SceneManager::GetActiveScene()->AddGameObject(bullet, LAYER::BULLET);
+		}
+	}
+}

--- a/Engine_Windows/qoSuperpositionGunScript.h
+++ b/Engine_Windows/qoSuperpositionGunScript.h
@@ -3,16 +3,20 @@
 
 namespace qo
 {
-	class GunScript : public Script
+	class SuperpositionGunScript : public Script
 	{
 	public:
-		GunScript();
-		virtual ~GunScript();
+		SuperpositionGunScript();
+		virtual ~SuperpositionGunScript();
 
 		void Initialize() override;
 		void Update() override;
 		void LateUpdate() override;
 		void Render() override;
+
+	private:
+		void Shoot();
+
 	};
 }
 

--- a/Shaders_SOURCE/CirclePS.hlsl
+++ b/Shaders_SOURCE/CirclePS.hlsl
@@ -1,0 +1,11 @@
+struct VTX_OUT
+{
+	float4 vPos : SV_Position;
+	float4 vColor : COLOR;
+};
+
+
+float4 PS(VTX_OUT _in) : SV_Target
+{
+	return _in.vColor;
+}

--- a/Shaders_SOURCE/CircleVS.hlsl
+++ b/Shaders_SOURCE/CircleVS.hlsl
@@ -1,0 +1,24 @@
+#include "ConstantBuffer.hlsli"
+
+struct VTX_IN
+{
+	float3 vPos : POSITION;
+	float4 vColor : COLOR;
+};
+
+struct VTX_OUT
+{
+	float4 vPos : SV_Position;
+	float4 vColor : COLOR;
+};
+
+VTX_OUT VS(VTX_IN _in)
+{
+	VTX_OUT output = (VTX_OUT) 0.f;
+    
+	output.vPos = float4(_in.vPos * Test_Scale.xyz, 1.f);
+	output.vPos.xyz += Test_Pos.xyz;
+	output.vColor = Test_Color; // 상수버퍼의 색상값으로 셋팅
+    
+	return output;
+}

--- a/Shaders_SOURCE/ConstantBuffer.hlsli
+++ b/Shaders_SOURCE/ConstantBuffer.hlsli
@@ -1,0 +1,15 @@
+
+cbuffer TRANSFORM : register(b0)
+{
+    float3 cbPos;
+    int padd1;
+    float3 cbScale;
+    int padd2;
+};
+
+cbuffer ColorTEST : register(b1)
+{
+    float4 Test_Pos;
+    float4 Test_Scale;
+    float4 Test_Color;
+};

--- a/Shaders_SOURCE/ConstantBuffer.hlsli
+++ b/Shaders_SOURCE/ConstantBuffer.hlsli
@@ -13,3 +13,10 @@ cbuffer ColorTEST : register(b1)
     float4 Test_Scale;
     float4 Test_Color;
 };
+
+cbuffer MATRIX : register(b0)
+{
+    row_major matrix World;
+    row_major matrix View;
+    row_major matrix Projection;
+}

--- a/Shaders_SOURCE/Shaders_SOURCE.vcxitems
+++ b/Shaders_SOURCE/Shaders_SOURCE.vcxitems
@@ -16,5 +16,8 @@
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)TriangleVS.hlsl" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TrianglePS.hlsl" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)ConstantBuffer.hlsli" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)CircleVS.hlsl" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)CirclePS.hlsl" />
   </ItemGroup>
 </Project>

--- a/Shaders_SOURCE/Shaders_SOURCE.vcxitems.filters
+++ b/Shaders_SOURCE/Shaders_SOURCE.vcxitems.filters
@@ -19,6 +19,9 @@
     <Filter Include="VS">
       <UniqueIdentifier>{f4c63185-6450-4d15-a9a9-b7e93bfea05e}</UniqueIdentifier>
     </Filter>
+    <Filter Include="LIB">
+      <UniqueIdentifier>{3c6915de-3cfe-4f03-9cc3-aa03a8b77e06}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)TriangleVS.hlsl">
@@ -26,6 +29,15 @@
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)TrianglePS.hlsl">
       <Filter>PS</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)CircleVS.hlsl">
+      <Filter>VS</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)CirclePS.hlsl">
+      <Filter>PS</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)ConstantBuffer.hlsli">
+      <Filter>LIB</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/Shaders_SOURCE/TriangleVS.hlsl
+++ b/Shaders_SOURCE/TriangleVS.hlsl
@@ -1,3 +1,4 @@
+#include "ConstantBuffer.hlsli"
 
 struct VTX_IN
 {
@@ -9,14 +10,6 @@ struct VTX_OUT
 {
 	float4 vPos : SV_Position;
 	float4 vColor : COLOR;
-};
-
-cbuffer TRANSFORM : register(b0)
-{
-	float3 cbPos;
-	int padd1;
-	float3 cbScale;
-	int padd2;
 };
 
 VTX_OUT VS_Test(VTX_IN _in)
@@ -32,13 +25,12 @@ VTX_OUT VS_Test(VTX_IN _in)
 	return output;
 }
 
-// 색상 테스트용 상수버퍼, 버텍스 쉐이더
-cbuffer ColorTEST : register(b1) // 레지스터 번호 주의
-{
-    float4 Test_Pos;
-    float4 Test_Scale;
-    float4 Test_Color;
-};
+
+
+// =========================
+// 색상 테스트용 버텍스 쉐이더
+// =========================
+
 
 VTX_OUT VS_Color_Test(VTX_IN _in)
 {
@@ -47,6 +39,6 @@ VTX_OUT VS_Color_Test(VTX_IN _in)
     output.vPos = float4(_in.vPos * Test_Scale.xyz, 1.f);
     output.vPos.xyz += Test_Pos.xyz;
     output.vColor = Test_Color; // 상수버퍼의 색상값으로 셋팅
-    
+
     return output;
 }

--- a/Shaders_SOURCE/TriangleVS.hlsl
+++ b/Shaders_SOURCE/TriangleVS.hlsl
@@ -31,3 +31,22 @@ VTX_OUT VS_Test(VTX_IN _in)
     
 	return output;
 }
+
+// 색상 테스트용 상수버퍼, 버텍스 쉐이더
+cbuffer ColorTEST : register(b1) // 레지스터 번호 주의
+{
+    float4 Test_Pos;
+    float4 Test_Scale;
+    float4 Test_Color;
+};
+
+VTX_OUT VS_Color_Test(VTX_IN _in)
+{
+    VTX_OUT output = (VTX_OUT) 0.f;
+    
+    output.vPos = float4(_in.vPos * Test_Scale.xyz, 1.f);
+    output.vPos.xyz += Test_Pos.xyz;
+    output.vColor = Test_Color; // 상수버퍼의 색상값으로 셋팅
+    
+    return output;
+}


### PR DESCRIPTION
feat :

Mesh, Shader 에서 색상을 지정하는것이 아닌,
상수버퍼에 Color 값을 넣고 받은 색상으로 렌더링 하는 방식,
상수 버퍼에 넣을 Color 값을 클래스 or 객체 마다 보유하고 있으면 됨

ConstantBuffer 클래스 - 상수버퍼 레지스터 등록을 위해 생성자에서 mType 객체를 설정하도록 제한

Graphics.h - CBSLOT_ColorTest 추가, eCBType 추가

Renderer 파일 - CBUFFER(ColorTestCB, CBSLOT_ColorTest)추가, ColorTestShader 쉐이더 extern변수 추가

Transform 클래스 - ColorTest 용 상수버퍼 셋팅 코드 추가

PlayScene - Ground 객체에 테스트용 쉐이더 적용

TriangleVS.hlsl - 색상 테스트용 상수버퍼,
VS_Color_Test 쉐이더 추가

Renderer : CircleMesh, CircleShader 추가

Shader 클래스 : SetTopology() 함수 추가

Transform 클래스 : Color 값 저장할 mColor 생성
임시로 Transform 클래스 멤버변수로 지정했음
추후에 color 값 지정 어디서할지 협의필요

ConstantBuffer.hlsli 파일 생성 : 상수버퍼 선언부 모아둔 파일 쉐이더파일에서 #include 해서 사용하면됨

CircleVS, CirclePS : TriangleVS 와 구분용으로 생성

Gun 클래스, Bullet 클래스 추상클래스로 변경

SuperpositionGun,SuperpositionBullet 생성

SuperpositionBullet - Wall 과 충돌시 Destroy 되도록 테스트 기능 추가

config :

Layer 클래스 : 주석처리된 부분 제거

Rigidbody 클래스 : mGravity ,mMaxGravity 값 수정