### PR TITLE
feat : 콜라이더 렌더 추가

### DIFF
--- a/Engine_SOURCE/qoCamera.cpp
+++ b/Engine_SOURCE/qoCamera.cpp
@@ -15,6 +15,7 @@ namespace qo
 		mLookAt.y = 0.f;
 		mLookAt.z = 0.f;
 	}
+
 	void Camera::Update()
 	{
 		if (Input::GetKeyState(KEY_CODE::LEFT) == KEY_STATE::PRESSED)

--- a/Engine_SOURCE/qoCollider.cpp
+++ b/Engine_SOURCE/qoCollider.cpp
@@ -1,5 +1,10 @@
 #include "qoCollider.h"
 #include "qoGameObject.h"
+#include "qoTransform.h"
+#include "qoResourceManager.h"
+#include "qoConstantBuffer.h"
+#include "qoRenderer.h"
+#include "qoCamera.h"
 
 namespace qo
 {
@@ -11,8 +16,11 @@ namespace qo
 		, mScale(math::Vector3(0.f, 0.f, 0.f))
 		, mOffset(math::Vector3(0.f, 0.f, 0.f))
 		, mAffectedCamera(true)
+		, mbIsCollision(false)
 		, mCollisionNumber(mCollisionCount++)
 	{
+		mMesh = ResourceManager::Find<Mesh>(L"BasicRectangleMesh");
+		mShader = ResourceManager::Find<Shader>(L"ColorTestShader2");
 	}
 
 	Collider::~Collider()
@@ -33,11 +41,53 @@ namespace qo
 
 	void Collider::Render()
 	{
+		if (mbIsCollision)
+		{
+			ConstantBuffer* Register1Cb = renderer::constantBuffers[(UINT)graphics::eCBType::Color_Test];
+			Vector3 OwnerPostion = GetOwner()->GetComponent<Transform>()->GetPosition();
+
+			renderer::ColorTestCB data = {};
+			math::Vector3 temp;
+			temp.x = OwnerPostion.x;
+			temp.y = OwnerPostion.y;
+			temp.z = OwnerPostion.z;
+			temp = Camera::CaculatePos(temp);
+
+			data.pos = math::Vector4(temp.x, temp.y, temp.z, 0.f);
+			data.scale = math::Vector4(mScale.x, mScale.y, mScale.z, 0.f);
+			data.color = math::Vector4(1.f, 0.f, 0.f, 0.f);
+			Register1Cb->SetData(&data);
+
+			Register1Cb->Bind(graphics::eShaderStage::VS);
+		}
+		else
+		{
+			ConstantBuffer* Register1Cb = renderer::constantBuffers[(UINT)graphics::eCBType::Color_Test];
+			Vector3 OwnerPostion = GetOwner()->GetComponent<Transform>()->GetPosition();
+
+			renderer::ColorTestCB data = {};
+			math::Vector3 temp;
+			temp.x = OwnerPostion.x;
+			temp.y = OwnerPostion.y;
+			temp.z = OwnerPostion.z;
+			temp = Camera::CaculatePos(temp);
+
+			data.pos = math::Vector4(temp.x, temp.y, temp.z, 0.f);
+			data.scale = math::Vector4(mScale.x, mScale.y, mScale.z, 0.f);
+			data.color = math::Vector4(0.f, 1.f, 0.f, 0.f);
+			Register1Cb->SetData(&data);
+
+			Register1Cb->Bind(graphics::eShaderStage::VS);
+		}
+
+		mShader->Update();
+		mMesh->Render();
 	}
 
 	void Collider::OnCollisionEnter(Collider* other)
 	{
 		GetOwner()->OnCollisionEnter(other);
+		mbIsCollision = true;
 	}
 
 	void Collider::OnCollisionStay(Collider* other)
@@ -48,5 +98,6 @@ namespace qo
 	void Collider::OnCollisionExit(Collider* other)
 	{
 		GetOwner()->OnCollisionExit(other);
+		mbIsCollision = false;
 	}
 }

--- a/Engine_SOURCE/qoCollider.h
+++ b/Engine_SOURCE/qoCollider.h
@@ -1,8 +1,11 @@
 #pragma once
 #include "qoComponent.h" 
+#include "qoMesh.h"
+#include "qoShader.h"
 
 namespace qo
 {
+	using namespace graphics;
 	class Collider : public Component
 	{
 	public:
@@ -34,8 +37,12 @@ namespace qo
 
 		math::Vector3 mScale;
 		math::Vector3 mOffset;
-		bool mbisCollision;
+		bool mbIsCollision;
 		bool mAffectedCamera;
+
+		// Collider Render
+		Mesh* mMesh;
+		Shader* mShader;
 	};
 }
 

--- a/Engine_SOURCE/qoRenderer.cpp
+++ b/Engine_SOURCE/qoRenderer.cpp
@@ -12,11 +12,13 @@ namespace qo::renderer
 	Mesh* TriangleMesh = nullptr;
 	Mesh* RectangleMesh = nullptr;
 	Mesh* CircleMesh = nullptr;
+	Mesh* BasicRectangleMesh = nullptr;
 
 	Shader* shader = nullptr;
 	Shader* ColorTestShader = nullptr;
 	Shader* CircleShader = nullptr;
-
+	Shader* ColorTestShader2 = nullptr;
+	
 	ConstantBuffer* constantBuffers[(UINT)graphics::eCBType::End];
 
 	void SetUpStates()
@@ -128,6 +130,65 @@ namespace qo::renderer
 
 		constantBuffers[(UINT)graphics::eCBType::Color_Test] = new ConstantBuffer(eCBType::Color_Test);
 		constantBuffers[(UINT)graphics::eCBType::Color_Test]->Create(sizeof(ColorTestCB));
+
+		vertices.clear();
+		indexes.clear();
+
+		// Basic Rentangle
+		/*vertices.resize(4);
+		vertices[0].pos = Vector3(-0.00125f, 0.002f, 0.0f);
+		vertices[0].color = Vector4(1.f, 0.f, 0.f, 1.f);
+
+		vertices[1].pos = Vector3(0.00125f, 0.002f, 0.0f);
+		vertices[1].color = Vector4(0.f, 1.f, 0.f, 1.f);
+
+		vertices[2].pos = Vector3(0.00125f, -0.002f, 0.0f);
+		vertices[2].color = Vector4(0.f, 0.f, 1.f, 1.f);
+
+		vertices[3].pos = Vector3(-0.00125f, -0.002f, 0.0f);
+		vertices[3].color = Vector4(0.f, 1.f, 0.f, 1.f);*/
+
+		vertices.resize(4);
+		vertices[0].pos = Vector3(-0.5f, 0.5f, 0.0f);
+		vertices[0].color = Vector4(1.f, 0.f, 0.f, 1.f);
+
+		vertices[1].pos = Vector3(0.5f, 0.5f, 0.0f);
+		vertices[1].color = Vector4(0.f, 1.f, 0.f, 1.f);
+
+		vertices[2].pos = Vector3(0.5f, -0.5f, 0.0f);
+		vertices[2].color = Vector4(0.f, 0.f, 1.f, 1.f);
+
+		vertices[3].pos = Vector3(-0.5f, -0.5f, 0.0f);
+		vertices[3].color = Vector4(0.f, 1.f, 0.f, 1.f);
+
+		// 인덱스
+		/*indexes.push_back(0);
+		indexes.push_back(1);
+		indexes.push_back(2);
+
+		indexes.push_back(0);
+		indexes.push_back(2);
+		indexes.push_back(3);*/
+
+		//// 테두리 사각형 인덱스
+		indexes.push_back(0);
+		indexes.push_back(1);
+
+		indexes.push_back(0);
+		indexes.push_back(3);
+
+		indexes.push_back(3);
+		indexes.push_back(2);
+
+		indexes.push_back(2);
+		indexes.push_back(1);
+
+		BasicRectangleMesh->CreateVertexBuffer(vertices.data(), 4);
+		BasicRectangleMesh->CreateIndexBuffer(indexes.data(), static_cast<UINT>(indexes.size()));
+		ResourceManager::Insert(L"BasicRectangleMesh", BasicRectangleMesh);
+
+		vertices.clear();
+		indexes.clear();
 	}
 
 	void LoadShader()
@@ -166,6 +227,17 @@ namespace qo::renderer
 			ColorTestShader->GetVSCode()->GetBufferPointer()
 			, ColorTestShader->GetVSCode()->GetBufferSize()
 			, ColorTestShader->GetInputLayoutAddressOf());
+		
+		//
+		ColorTestShader2->Create(eShaderStage::VS, L"TriangleVS.hlsl", "VS_Color_Test");
+		ColorTestShader2->Create(eShaderStage::PS, L"TrianglePS.hlsl", "PS_Test");
+		ColorTestShader2->SetTopology(D3D11_PRIMITIVE_TOPOLOGY::D3D10_PRIMITIVE_TOPOLOGY_LINELIST);
+		ResourceManager::Insert(L"ColorTestShader2", ColorTestShader2);
+
+		GetDevice()->CreateInputLayout(InputLayouts, 2,
+			ColorTestShader2->GetVSCode()->GetBufferPointer()
+			, ColorTestShader2->GetVSCode()->GetBufferSize()
+			, ColorTestShader2->GetInputLayoutAddressOf());
 
 		// Circle Shader
 		CircleShader->Create(eShaderStage::VS, L"CircleVS.hlsl", "VS");
@@ -184,10 +256,12 @@ namespace qo::renderer
 		TriangleMesh = new Mesh();
 		RectangleMesh = new Mesh();
 		CircleMesh = new Mesh();
+		BasicRectangleMesh = new Mesh(); 
 
 		shader = new Shader();
 		ColorTestShader = new Shader();
 		CircleShader = new Shader();
+		ColorTestShader2 = new Shader();
 
 		LoadShader();
 		SetUpStates();
@@ -199,10 +273,12 @@ namespace qo::renderer
 		delete TriangleMesh;
 		delete RectangleMesh;
 		delete CircleMesh;
+		delete BasicRectangleMesh;
 
 		delete shader;
 		delete ColorTestShader;
 		delete CircleShader;
+		delete ColorTestShader2;
 
 		delete constantBuffers[(UINT)graphics::eCBType::Transform];
 		delete constantBuffers[(UINT)graphics::eCBType::Color_Test];

--- a/Engine_SOURCE/qoRenderer.h
+++ b/Engine_SOURCE/qoRenderer.h
@@ -43,11 +43,16 @@ namespace qo::renderer
 	extern Mesh* TriangleMesh;
 	extern Mesh* RectangleMesh;
 	extern Mesh* CircleMesh;
-
+	
 	extern Shader* shader;
 	extern Shader* ColorTestShader;
 	extern Shader* CircleShader;
 
+	// Basic Collider
+	extern Mesh* BasicRectangleMesh;
+	extern Shader* ColorTestShader2;
+
+	// Constant Buffer
 	extern ConstantBuffer* constantBuffers[];
 
 	// Initialize the renderer

--- a/Engine_Windows/qoPlayScene.cpp
+++ b/Engine_Windows/qoPlayScene.cpp
@@ -62,7 +62,7 @@ namespace qo
 		GroundMeshRenderer->SetShader(ResourceManager::Find<Shader>(L"ColorTestShader")); 
 
 		Collider* GroundCollider = ground->AddComponent<Collider>();
-		GroundCollider->SetScale(Vector3(1.f, 0.25f, 0.f));
+		GroundCollider->SetScale(Vector3(1.f, 0.3f, 0.f));
 
 		AddGameObject(ground, LAYER::GROUND);
 


### PR DESCRIPTION
Collider
1. Collider 생성자에서 렌더에 필요한 mesh ,shader 지정
2. Render 함수에서는 meshrender와 같은 방법으로 실행
3. Collider 클래스 mbIsCollision bool 타입 변수 추가
4. CollisionEnter,Stay 함수에 mbIsCollision 변수를 통해 충돌 여부를 판별

Renderer
1. Collider에서 사용할 Mesh, Shader 생성
- BasicRectangleMesh, ColorTestShader2
2. BasicRectangleMesh는 scale에 맞게 표시되게끔 Mesh 생성
3. line shader 생성을 위해 ColorTestShader2 생성

Result
1. 충돌 여부 판단을 위해 Collider rendering이 추가 되었습니다.
2. 충돌 시 Collider 색깔이 빨간색으로 변환 됩니다.

Next Plans
1. 충돌 시 사라지는 물체로 인해 Collider 색깔이 빨간색으로 고정되어버리는 버그 fix하겠습니다.
