### PR TITLE
config : 파괴되는 물체에 의한 충돌로 인해 항상 충돌 되어 있는 상태였던 물체 상태 해제 함수 추가

### DIFF
--- a/Engine_SOURCE/qoCollisionManager.cpp
+++ b/Engine_SOURCE/qoCollisionManager.cpp
@@ -142,4 +142,48 @@ namespace qo
 			return false;
 		}
 	}
+
+	void CollisionManager::ForceCollisionExit(Collider* deadcol)
+	{
+		std::map<UINT64, bool>::iterator iter = mCollisionMap.begin();
+		Scene* ActiveScene = SceneManager::GetActiveScene();
+
+		for (;iter != mCollisionMap.end() ;iter++)
+		{
+			ColliderID temp = {};
+			temp.id = iter->first;
+			if (temp.left == deadcol->GetCollisionNumber())
+			{
+				//mCollisionMap.erase(iter);
+				for (int layer = 0;layer != LAYER::MAX;layer++)
+				{
+					std::vector<GameObject*> GameObjects = ActiveScene->GetLayer((LAYER)layer)->GetGameObjects();
+					for (GameObject* obj : GameObjects)
+					{
+						if (obj->GetComponent<Collider>()->GetCollisionNumber() == temp.right)
+						{
+							obj->GetComponent<Collider>()->OnCollisionExit(deadcol);
+							break;
+						}
+					}
+				}
+			}
+			else if (temp.right == deadcol->GetCollisionNumber())
+			{
+				//mCollisionMap.erase(iter);
+				for (int layer = 0;layer != LAYER::MAX;layer++)
+				{
+					std::vector<GameObject*> GameObjects = ActiveScene->GetLayer((LAYER)layer)->GetGameObjects();
+					for (GameObject* obj : GameObjects)
+					{
+						if (obj->GetComponent<Collider>()->GetCollisionNumber() == temp.left)
+						{
+							obj->GetComponent<Collider>()->OnCollisionExit(deadcol);
+							break;
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/Engine_SOURCE/qoCollisionManager.h
+++ b/Engine_SOURCE/qoCollisionManager.h
@@ -26,6 +26,8 @@ namespace qo
 		static void LayerCollision(class Scene* scene, LAYER left, LAYER right);
 		static void ColliderCollision(Collider* left, Collider* right);
 		static bool Intersect(Collider* left, Collider* right);
+		
+		static void ForceCollisionExit(Collider* deadcol);
 
 	private:
 		static std::map<UINT64, bool> mCollisionMap;

--- a/Engine_SOURCE/qoLayer.cpp
+++ b/Engine_SOURCE/qoLayer.cpp
@@ -1,4 +1,5 @@
 #include "qoLayer.h"
+#include "qoCollisionManager.h"
 
 namespace qo
 {
@@ -44,6 +45,7 @@ namespace qo
 			if ((*iter)->GetGameObjectState() == GameObject::eState::Dead)
 			{
 				GameObject* obj = *iter;
+				CollisionManager::ForceCollisionExit(obj->GetComponent<Collider>());
 				iter = mGameObjects.erase(iter);
 				delete obj;
 				obj = nullptr;


### PR DESCRIPTION
CollisionManager.h
1. ForceCollisionExit(GameObject* deadObj) 선언 추가

CollisionManager.cpp
1. ForceCollisionExit(GameObject* deadObj) 정의 추가
2. 죽은 오브젝트에 collider id를 통해 충돌한 물체들의 colldier의 OnCollisionExit()함수를 호출해주는 방식

qoLayer.cpp
1. 죽은 오브젝트를 처리하기 전에 죽은 오브젝트가 충돌한 물체들의 충돌 상태를 해제시키는 ForceCollisionExit 코드 추가

Result
1. 이제 파괴된 물체와 충돌된 물체가 파괴된 물체에 의해 계속 충돌 중이던 버그가 수정되었습니다! 