### PR TITLE
feat : Architecture ↔ 플레이어 충돌 벗어날 경우 Ground false 추가, TeleportationGun 순간이동 기능 추가

### DIFF
--- a/Engine_Windows/qoBarrier.cpp
+++ b/Engine_Windows/qoBarrier.cpp
@@ -88,7 +88,7 @@ namespace qo
 				{
 					// 벽 상단 충돌
 					Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
-					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f) + 0.01f, 0);
+					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f), 0);
 					PlayerRigidbody->SetGround(true);
 				}
 			}
@@ -150,7 +150,7 @@ namespace qo
 				{
 					// 벽 상단 충돌
 					Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
-					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f) + 0.01f, 0);
+					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f), 0);
 					PlayerRigidbody->SetGround(true);
 				}
 			}
@@ -159,5 +159,12 @@ namespace qo
 
 	void Barrier::OnCollisionExit(Collider* other)
 	{
+		Player* player = dynamic_cast<Player*>(other->GetOwner());
+
+		if (player != nullptr)
+		{
+			Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
+			PlayerRigidbody->SetGround(false);
+		}
 	}
 }

--- a/Engine_Windows/qoDestructibleWall.cpp
+++ b/Engine_Windows/qoDestructibleWall.cpp
@@ -91,7 +91,7 @@ namespace qo
 				{
 					// 벽 상단 충돌
 					Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
-					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f) + 0.01f, 0);
+					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f), 0);
 					PlayerRigidbody->SetGround(true);
 				}
 			}
@@ -160,7 +160,7 @@ namespace qo
 				{
 					// 벽 상단 충돌
 					Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
-					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f) + 0.01f, 0);
+					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f), 0);
 					PlayerRigidbody->SetGround(true);
 				}
 			}
@@ -169,5 +169,12 @@ namespace qo
 
 	void DestuctibleWall::OnCollisionExit(Collider* other)
 	{
+		Player* player = dynamic_cast<Player*>(other->GetOwner());
+
+		if (player != nullptr)
+		{
+			Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
+			PlayerRigidbody->SetGround(false);
+		}
 	}
 }

--- a/Engine_Windows/qoFloor.cpp
+++ b/Engine_Windows/qoFloor.cpp
@@ -88,7 +88,7 @@ namespace qo
 				{
 					// 벽 상단 충돌
 					Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
-					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f) + 0.01f, 0);
+					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f), 0);
 					PlayerRigidbody->SetGround(true);
 				}
 			}
@@ -150,7 +150,7 @@ namespace qo
 				{
 					// 벽 상단 충돌
 					Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
-					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f) + 0.01f, 0);
+					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f), 0);
 					PlayerRigidbody->SetGround(true);
 				}
 			}
@@ -159,5 +159,12 @@ namespace qo
 
 	void Floor::OnCollisionExit(Collider* other)
 	{
+		Player* player = dynamic_cast<Player*>(other->GetOwner());
+
+		if (player != nullptr)
+		{
+			Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
+			PlayerRigidbody->SetGround(false);
+		}
 	}
 }

--- a/Engine_Windows/qoLockedDoor.cpp
+++ b/Engine_Windows/qoLockedDoor.cpp
@@ -96,7 +96,7 @@ namespace qo
 				{
 					// 벽 상단 충돌
 					Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
-					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f) + 0.01f, 0);
+					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f), 0);
 					PlayerRigidbody->SetGround(true);
 				}
 			}
@@ -158,7 +158,7 @@ namespace qo
 				{
 					// 벽 상단 충돌
 					Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
-					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f) + 0.01f, 0);
+					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f), 0);
 					PlayerRigidbody->SetGround(true);
 				}
 			}
@@ -167,5 +167,12 @@ namespace qo
 
 	void LockedDoor::OnCollisionExit(Collider* other)
 	{
+		Player* player = dynamic_cast<Player*>(other->GetOwner());
+
+		if (player != nullptr)
+		{
+			Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
+			PlayerRigidbody->SetGround(false);
+		}
 	}
 }

--- a/Engine_Windows/qoPlayScene.cpp
+++ b/Engine_Windows/qoPlayScene.cpp
@@ -112,6 +112,23 @@ namespace qo
 		AddGameObject(lockeddoor, LAYER::WALL);
 
 		CollisionManager::CollisionLayerCheck(LAYER::PLAYER, LAYER::WALL, TRUE);
+
+
+		// 잠긴 문 개체 생성
+		LockedDoor* test = new LockedDoor();
+		LockedDoorTransform = test->AddComponent<Transform>();
+		LockedDoorTransform->SetPositionInPixels(900, 200, 0);
+		LockedDoorTransform->SetScaleInPixels(400, 400, 0);
+		LockedDoorTransform->SetColor(Vector4(0.5f, 0.5f, 0.5f, 0.f));
+
+		LockedDoorMeshRenderer = test->AddComponent<MeshRenderer>();
+		LockedDoorMeshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"RectangleMesh"));
+		LockedDoorMeshRenderer->SetShader(ResourceManager::Find<Shader>(L"ColorTestShader"));
+
+		LockedDoorCollider = test->AddComponent<Collider>();
+		LockedDoorCollider->SetScale(LockedDoorTransform->GetScale());
+
+		AddGameObject(test, LAYER::WALL);
 	}
 
 	void PlayScene::Update()

--- a/Engine_Windows/qoPlayScene.cpp
+++ b/Engine_Windows/qoPlayScene.cpp
@@ -112,23 +112,6 @@ namespace qo
 		AddGameObject(lockeddoor, LAYER::WALL);
 
 		CollisionManager::CollisionLayerCheck(LAYER::PLAYER, LAYER::WALL, TRUE);
-
-
-		// 잠긴 문 개체 생성
-		LockedDoor* test = new LockedDoor();
-		LockedDoorTransform = test->AddComponent<Transform>();
-		LockedDoorTransform->SetPositionInPixels(900, 200, 0);
-		LockedDoorTransform->SetScaleInPixels(400, 400, 0);
-		LockedDoorTransform->SetColor(Vector4(0.5f, 0.5f, 0.5f, 0.f));
-
-		LockedDoorMeshRenderer = test->AddComponent<MeshRenderer>();
-		LockedDoorMeshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"RectangleMesh"));
-		LockedDoorMeshRenderer->SetShader(ResourceManager::Find<Shader>(L"ColorTestShader"));
-
-		LockedDoorCollider = test->AddComponent<Collider>();
-		LockedDoorCollider->SetScale(LockedDoorTransform->GetScale());
-
-		AddGameObject(test, LAYER::WALL);
 	}
 
 	void PlayScene::Update()

--- a/Engine_Windows/qoPlayerScript.cpp
+++ b/Engine_Windows/qoPlayerScript.cpp
@@ -83,8 +83,12 @@ namespace qo
 		// Jump
 		if (Input::GetKeyState(KEY_CODE::SPACE) == KEY_STATE::DOWN)
 		{
-			Rigidbody* rigidbody = mPlayer->GetComponent<Rigidbody>();
+			// 점프시 Colider Exit를 위해서 띄우기 추가
+			Transform* tranform = mPlayer->GetComponent<Transform>();
+			Vector3 pos = tranform->GetPosition();
+			tranform->SetPosition(Vector3(pos.x, pos.y + 0.05f, pos.z));
 
+			Rigidbody* rigidbody = mPlayer->GetComponent<Rigidbody>();
 			rigidbody->SetGround(false);
 			rigidbody->SetVelocity(Vector3(0.f, 1.f, 0.f));
 			mPlayer->mState = ePlayerState::Jump;
@@ -111,8 +115,12 @@ namespace qo
 		// Jump
 		if (Input::GetKeyState(KEY_CODE::SPACE) == KEY_STATE::DOWN)
 		{
-			Rigidbody* rigidbody = mPlayer->GetComponent<Rigidbody>();
+			// 점프시 Colider Exit를 위해서 띄우기 추가
+			Transform* tranform = mPlayer->GetComponent<Transform>();
+			Vector3 pos = tranform->GetPosition();
+			tranform->SetPosition(Vector3(pos.x, pos.y + 0.05f, pos.z));
 
+			Rigidbody* rigidbody = mPlayer->GetComponent<Rigidbody>();
 			rigidbody->SetGround(false);
 			rigidbody->SetVelocity(Vector3(0.f, 1.f, 0.f));
 			mPlayer->mState = ePlayerState::Jump;
@@ -148,8 +156,12 @@ namespace qo
 		// 임시 더블 점프 
 		if (Input::GetKeyState(KEY_CODE::SPACE) == KEY_STATE::DOWN)
 		{
-			Rigidbody* rigidbody = mPlayer->GetComponent<Rigidbody>();
+			// 점프시 Colider Exit를 위해서 띄우기 추가
+			Transform* tranform = mPlayer->GetComponent<Transform>();
+			Vector3 pos = tranform->GetPosition();
+			tranform->SetPosition(Vector3(pos.x, pos.y + 0.05f, pos.z));
 
+			Rigidbody* rigidbody = mPlayer->GetComponent<Rigidbody>();
 			rigidbody->SetGround(false);
 			rigidbody->SetVelocity(Vector3(0.f, 1.f, 0.f));
 			mPlayer->mState = ePlayerState::Jump;

--- a/Engine_Windows/qoTeleportationGun.cpp
+++ b/Engine_Windows/qoTeleportationGun.cpp
@@ -4,6 +4,7 @@ namespace qo
 {
 	TeleportationGun::TeleportationGun(Player* owner, UINT bulletCount)
 		: Gun(eGunType::Teleportation, owner, bulletCount)
+		, mTargetBullet(nullptr)
 	{
 	}
 

--- a/Engine_Windows/qoTeleportationGun.h
+++ b/Engine_Windows/qoTeleportationGun.h
@@ -3,6 +3,7 @@
 
 namespace qo
 {
+	class TeleportationBullet;
 	class TeleportationGun : public Gun
 	{
 	public:
@@ -13,6 +14,13 @@ namespace qo
 		virtual void Update() override;
 		virtual void LateUpdate() override;
 		virtual void Render() override;
+
+		void SetTargetBullet(TeleportationBullet* targetBullet) { mTargetBullet = targetBullet; };
+		TeleportationBullet* GetTargetBullet() const { return mTargetBullet; }
+
+	private:
+		TeleportationBullet* mTargetBullet;
+		
 	};
 }
 

--- a/Engine_Windows/qoWall.cpp
+++ b/Engine_Windows/qoWall.cpp
@@ -89,7 +89,7 @@ namespace qo
 				{
 					// 벽 상단 충돌
 					Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
-					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f) + 0.01f, 0);
+					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f), 0);
 					PlayerRigidbody->SetGround(true);
 				}
 			}
@@ -151,7 +151,7 @@ namespace qo
 				{
 					// 벽 상단 충돌
 					Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
-					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f) + 0.01f, 0);
+					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f), 0);
 					PlayerRigidbody->SetGround(true);
 				}
 			}
@@ -160,5 +160,12 @@ namespace qo
 
 	void Wall::OnCollisionExit(Collider* other)
 	{
+		Player* player = dynamic_cast<Player*>(other->GetOwner());
+
+		if (player != nullptr)
+		{
+			Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
+			PlayerRigidbody->SetGround(false);
+		}
 	}
 }


### PR DESCRIPTION
Architecture 오브젝트 변경사항 :
1. OnCollisionExit() 시 Player SetGround(falae) 호출 하도록 설정

2. 벽 상단 충돌 시 플레이어 위치 0.01f 올려주던 코드 삭제

PlayerScript : 점프키 눌렀을경우 0.05f 위로 올려주는 코드추가
- Architecture 오브젝트의 OnCollisionExit() 함수로 호출을 위해서 적용

TeleportationGun 순간이동 기능 추가 :
마지막으로 쏜 총알을 TargetBullet 설정하고 마우스 우클릭시 해당 총알 위치로 순간이동하는 기능 추가