### PR TITLE
fix : TeleportationBullet 벽에 부딫혀서 삭제시 TeleportationGun이 들고있는 Target이 …

### DIFF
--- a/Engine_Windows/qoTeleportationBullet.cpp
+++ b/Engine_Windows/qoTeleportationBullet.cpp
@@ -1,16 +1,23 @@
 #include "qoTeleportationBullet.h"
 #include "qoCollider.h"
 #include "ArchitectureInclude.h"
+#include "qoTeleportationGun.h"
 
 namespace qo
 {
-	TeleportationBullet::TeleportationBullet(Vector3 Dir)
+	TeleportationBullet::TeleportationBullet(TeleportationGun* onwer, Vector3 Dir)
 		: Bullet(Dir)
+		, mOwner(onwer)
 	{
 	}
 
 	TeleportationBullet::~TeleportationBullet()
 	{
+		// 총알 삭제시 Onwer 의 타겟이 이 총알이면 nullptr로 초기화
+		if (mOwner->GetTargetBullet() == this)
+		{
+			mOwner->SetTargetBullet(nullptr);
+		}
 	}
 
 	void TeleportationBullet::Initialize()

--- a/Engine_Windows/qoTeleportationBullet.h
+++ b/Engine_Windows/qoTeleportationBullet.h
@@ -3,10 +3,12 @@
 
 namespace qo
 {
+	class TeleportationGun;
+
 	class TeleportationBullet : public Bullet
 	{
 	public:
-		TeleportationBullet(Vector3 Dir);
+		TeleportationBullet(TeleportationGun* owner, Vector3 Dir);
 		virtual ~TeleportationBullet();
 
 		virtual void Initialize() override;
@@ -17,6 +19,10 @@ namespace qo
 		virtual void OnCollisionEnter(class Collider* other) override;
 		virtual void OnCollisionStay(class Collider* other) override;
 		virtual void OnCollisionExit(class Collider* other) override;
+
+	public:
+		TeleportationGun* mOwner;
+
 	};
 }
 

--- a/Engine_Windows/qoTeleportationGunScript.cpp
+++ b/Engine_Windows/qoTeleportationGunScript.cpp
@@ -35,6 +35,7 @@ namespace qo
 
 		if (teleportationGun == nullptr)
 			return;
+
 		// ==========================
 		// ÃÑ¾Ë ¹ß»ç
 		// ==========================
@@ -113,7 +114,7 @@ namespace qo
 			// ================================================
 			// ÃÑ¾Ë »ý¼º
 			// ================================================
-			TeleportationBullet* bullet = new TeleportationBullet(Dir);
+			TeleportationBullet* bullet = new TeleportationBullet(teleportationGun, Dir);
 			Transform* tr = bullet->AddComponent<Transform>();
 			tr->SetPosition(GunPos); // ÃÑ¾Ë ½ÃÀÛÀ§Ä¡´Â ÃÑÀ§Ä¡·Î ¼³Á¤
 			tr->SetScale(Vector3(0.1f, 0.1f, 0.1f));


### PR DESCRIPTION
…댕글링포인터가 되는 버그 수정

TeleportationBullet 소멸자에서 TeleportationGun이 들고있는 Target이 자기자신이면 nullptr로 초기화하도록 설정