### PR TITLE
feat : Camera shake effect 추가 + ForceExit syntax error 수정 + 연쇄 총알 추가 …

### DIFF
--- a/Engine_SOURCE/qoCamera.h
+++ b/Engine_SOURCE/qoCamera.h
@@ -4,6 +4,30 @@
 
 namespace qo
 {
+	enum class CAM_EFFECT
+	{
+		Shake,
+		None
+	};
+
+	enum class ShakeDir
+	{
+		Vertical,
+		Horizontal,
+		Comprehensive,
+		None
+	};
+
+	struct tCamEffect
+	{
+		CAM_EFFECT eEffect;
+		float fDuration;
+		float fCurTime;
+		ShakeDir eShakeDir;
+		float fDistance;
+		float fSpeed;
+	};
+
 	class Camera
 	{
 	public:
@@ -15,11 +39,28 @@ namespace qo
 		static void SetLookAt(math::Vector3 lookat) { mLookAt = lookat; }
 		static math::Vector3 GetLookAt() { return mLookAt; }
 
+	public:
+		static void ShakeCam(float _fDuration, ShakeDir _eShakeDir, float _fDistance, float _fSpeed)
+		{
+			tCamEffect ef = {};
+			ef.eEffect = CAM_EFFECT::Shake;
+			ef.eShakeDir = _eShakeDir;
+			ef.fDuration = _fDuration;
+			ef.fCurTime = 0.f;
+			ef.fDistance = _fDistance;
+			ef.fSpeed = _fSpeed;
+
+			m_listCamEffect.push_back(ef);
+		}
+
 	private:
 		static math::Vector3 mResolution;
 		static math::Vector3 mLookAt;
 		static math::Vector3 mDiffDistance;
 		static GameObject* mTarget;
+
+		static CAM_EFFECT mCurCamEffect;
+		static std::list<tCamEffect> m_listCamEffect;
 	};
 }
 

--- a/Engine_SOURCE/qoCollisionManager.cpp
+++ b/Engine_SOURCE/qoCollisionManager.cpp
@@ -160,6 +160,9 @@ namespace qo
 					std::vector<GameObject*> GameObjects = ActiveScene->GetLayer((LAYER)layer)->GetGameObjects();
 					for (GameObject* obj : GameObjects)
 					{
+						if (obj->GetComponent<Collider>() == nullptr)
+							continue;
+
 						if (obj->GetComponent<Collider>()->GetCollisionNumber() == temp.right)
 						{
 							obj->GetComponent<Collider>()->OnCollisionExit(DeadCol);
@@ -167,7 +170,7 @@ namespace qo
 						}
 					}
 				}
-				iter->second == false;
+				iter->second = false;
 			}
 			else if (temp.right == DeadCol->GetCollisionNumber())
 			{
@@ -177,6 +180,9 @@ namespace qo
 					std::vector<GameObject*> GameObjects = ActiveScene->GetLayer((LAYER)layer)->GetGameObjects();
 					for (GameObject* obj : GameObjects)
 					{
+						if (obj->GetComponent<Collider>() == nullptr)
+							continue;
+
 						if (obj->GetComponent<Collider>()->GetCollisionNumber() == temp.left)
 						{
 							obj->GetComponent<Collider>()->OnCollisionExit(DeadCol);
@@ -184,7 +190,7 @@ namespace qo
 						}
 					}
 				}
-				iter->second == false;
+				iter->second = false;
 			}
 		}
 	}

--- a/Engine_SOURCE/qoEnums.h
+++ b/Engine_SOURCE/qoEnums.h
@@ -9,7 +9,7 @@ namespace qo::enums
 		FLOOR,
 		WALL,
 		BULLET,
-		MONSETR,
+		MONSTER,
 		MAX = 16,
 	};
 

--- a/Engine_SOURCE/qoEnums.h
+++ b/Engine_SOURCE/qoEnums.h
@@ -9,6 +9,7 @@ namespace qo::enums
 		FLOOR,
 		WALL,
 		BULLET,
+		MONSETR,
 		MAX = 16,
 	};
 

--- a/Engine_SOURCE/qoTransform.cpp
+++ b/Engine_SOURCE/qoTransform.cpp
@@ -8,7 +8,8 @@ namespace qo
 
 	Transform::Transform()
 		: Component(COMPONENTTYPE::TRANSFORM)
-		, mColor(math::Vector4(1.f, 1.f, 1.f, 0.f))
+		, mColor(math::Vector4(1.f, 1.f, 1.f, 0.f))\
+		, mbAffectedCamera(true)
 	{
 
 	}
@@ -44,7 +45,9 @@ namespace qo
 			temp.x = mPosition.x;
 			temp.y = mPosition.y;
 			temp.z = mPosition.z;
-			temp = Camera::CaculatePos(temp);
+
+			if(mbAffectedCamera)
+				temp = Camera::CaculatePos(temp);
 
 			data.pos = temp;
 			data.scale = mScale;
@@ -63,7 +66,9 @@ namespace qo
 			temp.x = mPosition.x;
 			temp.y = mPosition.y;
 			temp.z = mPosition.z;
-			temp = Camera::CaculatePos(temp);
+			
+			if (mbAffectedCamera)
+				temp = Camera::CaculatePos(temp);
 
 			data.pos = math::Vector4(temp.x, temp.y, temp.z, 0.f);
 			data.scale = math::Vector4(mScale.x, mScale.y, mScale.z, 0.f);

--- a/Engine_SOURCE/qoTransform.h
+++ b/Engine_SOURCE/qoTransform.h
@@ -35,6 +35,8 @@ namespace qo
 		void SetPositionInPixels(float xPixels, float yPixels, float z);
 		void SetScaleInPixels(float widthInPixels, float heightInPixels, float z);
 
+		void SetAffectedCamera(bool affectedcamera) { mbAffectedCamera = affectedcamera; }
+
 	private:
 		Vector3 mPosition;
 		Vector3 mRotation;
@@ -42,5 +44,8 @@ namespace qo
 
 		// 상수버퍼에 전달해줄 Color 값
 		Vector4 mColor;
+
+		// Camera Affected
+		bool mbAffectedCamera;
 	};
 }

--- a/Engine_Windows/Engine_Windows.vcxproj
+++ b/Engine_Windows/Engine_Windows.vcxproj
@@ -32,6 +32,8 @@
     <ClInclude Include="qoFloor.h" />
     <ClInclude Include="qoGun.h" />
     <ClInclude Include="qoGunScript.h" />
+    <ClInclude Include="qoHPUI.h" />
+    <ClInclude Include="qoHPUIScript.h" />
     <ClInclude Include="qoLabGuard.h" />
     <ClInclude Include="qoLabGuardScript.h" />
     <ClInclude Include="qoLabTurret.h" />
@@ -49,6 +51,8 @@
     <ClInclude Include="qoTeleportationBullet.h" />
     <ClInclude Include="qoTeleportationGun.h" />
     <ClInclude Include="qoTeleportationGunScript.h" />
+    <ClInclude Include="qoUI.h" />
+    <ClInclude Include="qoUIScript.h" />
     <ClInclude Include="qoWall.h" />
   </ItemGroup>
   <ItemGroup>
@@ -64,6 +68,8 @@
     <ClCompile Include="qoFloor.cpp" />
     <ClCompile Include="qoGun.cpp" />
     <ClCompile Include="qoGunScript.cpp" />
+    <ClCompile Include="qoHPUI.cpp" />
+    <ClCompile Include="qoHPUIScript.cpp" />
     <ClCompile Include="qoLabGuard.cpp" />
     <ClCompile Include="qoLabGuardScript.cpp" />
     <ClCompile Include="qoLabTurret.cpp" />
@@ -80,6 +86,8 @@
     <ClCompile Include="qoTeleportationBullet.cpp" />
     <ClCompile Include="qoTeleportationGun.cpp" />
     <ClCompile Include="qoTeleportationGunScript.cpp" />
+    <ClCompile Include="qoUI.cpp" />
+    <ClCompile Include="qoUIScript.cpp" />
     <ClCompile Include="qoWall.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/Engine_Windows/Engine_Windows.vcxproj.filters
+++ b/Engine_Windows/Engine_Windows.vcxproj.filters
@@ -79,6 +79,18 @@
     <Filter Include="Scenes\Level4">
       <UniqueIdentifier>{65de5abb-9ef2-4d13-9c68-d1835a675f33}</UniqueIdentifier>
     </Filter>
+    <Filter Include="GameObjects\UI">
+      <UniqueIdentifier>{89b8d5c4-e209-431a-9998-3f886bc1e2c1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Scripts\UI">
+      <UniqueIdentifier>{7dbc1df8-e6b9-4725-aecf-9c1a1329c63f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="GameObjects\UI\HP">
+      <UniqueIdentifier>{eb02e067-fd88-4163-99d6-7eae7a6353b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Scripts\UI\HP">
+      <UniqueIdentifier>{72fedc18-6e57-4d2f-9d85-534b7aca830e}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="qoPlayScene.cpp">
@@ -168,6 +180,18 @@
     <ClCompile Include="qoStage1_2.cpp">
       <Filter>Scenes\Level1</Filter>
     </ClCompile>
+    <ClCompile Include="qoUI.cpp">
+      <Filter>GameObjects\UI</Filter>
+    </ClCompile>
+    <ClCompile Include="qoUIScript.cpp">
+      <Filter>Scripts\UI</Filter>
+    </ClCompile>
+    <ClCompile Include="qoHPUI.cpp">
+      <Filter>GameObjects\UI\HP</Filter>
+    </ClCompile>
+    <ClCompile Include="qoHPUIScript.cpp">
+      <Filter>Scripts\UI\HP</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="qoPlayScene.h">
@@ -251,9 +275,6 @@
     <ClInclude Include="qoFloor.h">
       <Filter>GameObjects\Architecture</Filter>
     </ClInclude>
-    <ClInclude Include="qoLoadScene.h">
-      <Filter>GameObjects\Architecture</Filter>
-    </ClInclude>
     <ClInclude Include="qoLockedDoor.h">
       <Filter>GameObjects\Architecture</Filter>
     </ClInclude>
@@ -263,5 +284,18 @@
     <ClInclude Include="qoStage1_2.h">
       <Filter>Scenes\Level1</Filter>
     </ClInclude>
+    <ClInclude Include="qoUI.h">
+      <Filter>GameObjects\UI</Filter>
+    </ClInclude>
+    <ClInclude Include="qoUIScript.h">
+      <Filter>Scripts\UI</Filter>
+    </ClInclude>
+    <ClInclude Include="qoHPUI.h">
+      <Filter>GameObjects\UI\HP</Filter>
+    </ClInclude>
+    <ClInclude Include="qoHPUIScript.h">
+      <Filter>Scripts\UI\HP</Filter>
+    </ClInclude>
+    <ClInclude Include="qoLoadScene.h" />
   </ItemGroup>
 </Project>

--- a/Engine_Windows/qoEntanglementBullet.cpp
+++ b/Engine_Windows/qoEntanglementBullet.cpp
@@ -62,8 +62,8 @@ namespace qo
 
 				// 이제 그 에너미와 가까운 에너미 탐색
 				Scene* ActiveScene = SceneManager::GetActiveScene();
-				std::vector<GameObject*> enemies = ActiveScene->GetLayer((UINT)LAYER::MONSETR)->GetGameObjects();
-				float min = 1.f;
+				std::vector<GameObject*> enemies = ActiveScene->GetLayer((UINT)LAYER::MONSTER)->GetGameObjects();
+				long double min = 1.f;
 
 				GameObject* target = nullptr;
 

--- a/Engine_Windows/qoEntanglementBullet.cpp
+++ b/Engine_Windows/qoEntanglementBullet.cpp
@@ -1,11 +1,17 @@
 #include "qoEntanglementBullet.h"
 #include "qoCollider.h"
 #include "ArchitectureInclude.h"
+#include "qoEnemy.h"
+#include "qoSceneManager.h"
+#include "qoMeshRenderer.h"
+#include "qoResourceManager.h"
+#include "qoBulletScript.h"
 
 namespace qo
 {
 	EntanglementBullet::EntanglementBullet(Vector3 Dir)
-		: Bullet(Dir)
+		: Bullet(Dir),
+		mIsEntangle(true)
 	{
 	}
 
@@ -37,11 +43,79 @@ namespace qo
 	{
 		Wall* wall = dynamic_cast<Wall*> (other->GetOwner());
 		DestuctibleWall* destuctibleWall = dynamic_cast<DestuctibleWall*> (other->GetOwner());
+		Enemy* enemy = dynamic_cast<Enemy*>(other->GetOwner());
 
 		// 충돌한 객체가 해당 객체면 Bullet 삭제
-		if (wall == nullptr
+		/*if (wall == nullptr
 			&& destuctibleWall == nullptr)
-			return;
+			return;*/
+
+		// 에너미 충돌시
+		if (mIsEntangle)
+		{
+			float Range = 1.f;
+
+			if (enemy != nullptr)
+			{
+				// 충돌한 에너미 객체의 포지션
+				Vector3 first = enemy->GetComponent<Transform>()->GetPosition();
+
+				// 이제 그 에너미와 가까운 에너미 탐색
+				Scene* ActiveScene = SceneManager::GetActiveScene();
+				std::vector<GameObject*> enemies = ActiveScene->GetLayer((UINT)LAYER::MONSETR)->GetGameObjects();
+				float min = 1.f;
+
+				GameObject* target = nullptr;
+
+				for (GameObject* enemyobj : enemies)
+				{
+					if (enemy == enemyobj)
+						continue;
+					Vector3 compare = enemyobj->GetComponent<Transform>()->GetPosition();
+					long double Distance = sqrt(pow(static_cast<long double>(first.x) - static_cast<long double>(compare.x), 2) +
+						pow(static_cast<long double>(first.x) - static_cast<long double>(compare.x), 2));
+					if (static_cast<long double>(Range) > Distance && static_cast<long double>(min) > Distance)
+					{
+						min = Distance;
+						target = enemyobj;
+					}
+				}
+
+				// 타겟을 찾았다면 연쇄 반응
+				if (target != nullptr)
+				{
+					Vector3 Dir = Vector3(0.f, 0.f, 0.f);
+					Vector3 targetPosition = target->GetComponent<Transform>()->GetPosition();
+					Dir.x = targetPosition.x - first.x;
+					Dir.y = targetPosition.y - first.y;
+
+					EntanglementBullet* bullet = new EntanglementBullet(Dir);
+					bullet->SetEntangle(false);
+					bullet->SetFirst(enemy);
+					Transform* tr = bullet->AddComponent<Transform>();
+					tr->SetPosition(first); // 총알 시작위치는 총위치로 설정
+					tr->SetScale(Vector3(0.1f, 0.1f, 0.1f));
+
+					MeshRenderer* meshRenderer = bullet->AddComponent<MeshRenderer>();
+					meshRenderer->SetMesh(ResourceManager::Find<Mesh>(L"CircleMesh"));
+					meshRenderer->SetShader(ResourceManager::Find<Shader>(L"CircleShader"));
+
+					Collider* col = bullet->AddComponent<Collider>();
+					col->SetScale(Vector3(0.1f, 0.1f, 0.1f));
+
+					bullet->AddComponent<BulletScript>();
+
+					bullet->Initialize();
+
+					SceneManager::GetActiveScene()->AddGameObject(bullet, LAYER::BULLET);
+				}
+			}
+		}
+		else
+		{
+			if (mFirst == enemy)
+				return;
+		}
 
 		Destroy(this);
 	}

--- a/Engine_Windows/qoEntanglementBullet.h
+++ b/Engine_Windows/qoEntanglementBullet.h
@@ -17,6 +17,14 @@ namespace qo
 		virtual void OnCollisionEnter(class Collider* other) override;
 		virtual void OnCollisionStay(class Collider* other) override;
 		virtual void OnCollisionExit(class Collider* other) override;
+
+	public:
+		void SetEntangle(bool Entangle) { mIsEntangle = Entangle; }
+		void SetFirst(GameObject* first) { mFirst = first; }
+
+	private:
+		bool mIsEntangle;
+		GameObject* mFirst;
 	};
 }
 

--- a/Engine_Windows/qoHPUI.cpp
+++ b/Engine_Windows/qoHPUI.cpp
@@ -1,0 +1,32 @@
+#include "qoHPUI.h"
+
+namespace qo
+{
+	HPUI::HPUI()
+	{
+	}
+
+	HPUI::~HPUI()
+	{
+	}
+
+	void HPUI::Initialize()
+	{
+		UI::Initialize();
+	}
+
+	void HPUI::Update()
+	{
+		UI::Update();
+	}
+
+	void HPUI::LateUpdate()
+	{
+		UI::LateUpdate();
+	}
+
+	void HPUI::Render()
+	{
+		UI::Render();
+	}
+}

--- a/Engine_Windows/qoHPUI.h
+++ b/Engine_Windows/qoHPUI.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "qoUI.h"
+
+namespace qo
+{
+	class HPUI : public UI
+	{
+	public:
+		HPUI();
+		virtual ~HPUI();
+
+		virtual void Initialize() override;
+		virtual void Update() override;
+		virtual void LateUpdate() override;
+		virtual void Render() override;
+
+	private:
+
+	};
+}
+
+

--- a/Engine_Windows/qoHPUIScript.cpp
+++ b/Engine_Windows/qoHPUIScript.cpp
@@ -1,0 +1,54 @@
+#include "qoHPUIScript.h"
+#include "qoTransform.h"
+#include "qoGameObject.h"
+#include "qoInput.h"
+
+namespace qo
+{
+	HPUIScript::HPUIScript()
+		: mMaxHP(100)
+		, mCurHP(100)
+	{
+		
+	}
+
+	HPUIScript::~HPUIScript()
+	{
+	}
+
+	void HPUIScript::Initialize()
+	{
+	}
+
+	void HPUIScript::Update()
+	{
+		if (Input::GetKeyState(KEY_CODE::O) == KEY_STATE::DOWN)
+		{
+			mCurHP -= 1;
+		}
+		
+		if (Input::GetKeyState(KEY_CODE::P) == KEY_STATE::DOWN)
+		{
+			mCurHP += 1;
+		}
+	}
+
+	void HPUIScript::LateUpdate()
+	{
+		Vector3 HPpos = GetOwner()->GetComponent<Transform>()->GetPosition();
+		Vector3 HPscale = GetOwner()->GetComponent<Transform>()->GetScale();
+
+		float scale = 0.25f * static_cast<float>(mCurHP) / static_cast<float>(mMaxHP);
+		float pos = -0.875f - ((0.25f - 0.25f * (static_cast<float>(mCurHP) / static_cast<float>(mMaxHP))) / 2.f);
+
+		HPscale.x = scale;
+		HPpos.x = pos;
+
+		GetOwner()->GetComponent<Transform>()->SetPosition(HPpos);
+		GetOwner()->GetComponent<Transform>()->SetScale(HPscale);
+	}
+
+	void HPUIScript::Render()
+	{
+	}
+}

--- a/Engine_Windows/qoHPUIScript.h
+++ b/Engine_Windows/qoHPUIScript.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "qoUIScript.h"
+
+namespace qo
+{
+	class HPUIScript : public UIScript
+	{
+	public:
+		HPUIScript();
+		virtual ~HPUIScript();
+
+		void Initialize() override;
+		void Update() override;
+		void LateUpdate() override;
+		void Render() override;
+
+	private:
+		UINT mMaxHP;
+		UINT mCurHP;
+	};
+}
+
+

--- a/Engine_Windows/qoPlayScene.cpp
+++ b/Engine_Windows/qoPlayScene.cpp
@@ -13,6 +13,9 @@
 #include "qoRigidbody.h"
 #include "qoCamera.h"
 
+#include "qoLabTurret.h"
+#include "qoHPUI.h"
+#include "qoHPUIScript.h"
 
 namespace qo
 {
@@ -56,7 +59,6 @@ namespace qo
 
 		AddGameObject(player, LAYER::PLAYER);
 		Camera::SetTarget(player);
-
 
 		// ¹Ù´Ú °´Ã¼ »ý¼º
 		Floor* floor = new Floor();

--- a/Engine_Windows/qoUI.cpp
+++ b/Engine_Windows/qoUI.cpp
@@ -1,0 +1,32 @@
+#include "qoUI.h"
+
+namespace qo
+{
+	UI::UI()
+	{
+	}
+
+	UI::~UI()
+	{
+	}
+
+	void UI::Initialize()
+	{
+		GameObject::Initialize();
+	}
+
+	void UI::Update()
+	{
+		GameObject::Update();
+	}
+
+	void UI::LateUpdate()
+	{
+		GameObject::LateUpdate();
+	}
+
+	void UI::Render()
+	{
+		GameObject::Render();
+	}
+}

--- a/Engine_Windows/qoUI.h
+++ b/Engine_Windows/qoUI.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "qoGameObject.h"
+
+namespace qo 
+{
+	class UI : public GameObject
+	{
+	public:
+		UI();
+		virtual ~UI();
+
+		virtual void Initialize() override;
+		virtual void Update() override;
+		virtual void LateUpdate() override;
+		virtual void Render() override;
+
+		virtual void OnCollisionEnter(Collider* other) override {};
+		virtual void OnCollisionStay(Collider* other) override {};
+		virtual void OnCollisionExit(Collider* other) override {};
+
+	private:
+
+	};
+}
+
+

--- a/Engine_Windows/qoUIScript.cpp
+++ b/Engine_Windows/qoUIScript.cpp
@@ -1,0 +1,28 @@
+#include "qoUIScript.h"
+
+namespace qo
+{
+	UIScript::UIScript()
+	{
+	}
+
+	UIScript::~UIScript()
+	{
+	}
+
+	void UIScript::Initialize()
+	{
+	}
+
+	void UIScript::Update()
+	{
+	}
+
+	void UIScript::LateUpdate()
+	{
+	}
+
+	void UIScript::Render()
+	{
+	}
+}

--- a/Engine_Windows/qoUIScript.h
+++ b/Engine_Windows/qoUIScript.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "qoScript.h"
+
+namespace qo
+{
+	class UIScript : public Script
+	{
+	public:
+		UIScript();
+		virtual ~UIScript();
+
+		void Initialize() override;
+		void Update() override;
+		void LateUpdate() override;
+		void Render() override;
+
+	private:
+
+	};
+}
+
+


### PR DESCRIPTION
…+ HPUI 추가(추후 수정)

qoCamera.cpp
1.  방향키로 카메라를 움직이던 로직을 삭제했습니다.
2. shakeeffect를 추가했습니다.

qoCamera.h
1. enum class CAM_EFFECT를 추가했습니다.
2. eunm class ShakeDir를 추가했습니다. 쉐이크 방향을 결정하는 enum class입니다.
3.  cameraeffect의 효과를 전달해줄 struct tCamEffect를 추가했습니다.
4.  카메라의 효과를 담아줄 list 자료형의 m_listCamEffect 멤버변수를 추가했습니다.
5.  현재 카메라의 효과를 저장해놓을 mCurCamEffect를 추가했습니다.
6.  쉐이크 효과를 저장할 수 있는 멤버함수 static void ShakeCam를 추가했습니다.

qoCollisionManager.cpp
1. syntax 실수인 == 부분을 =으로 수정했습니다.
2. forceexit함수에 collider를 가지고 있지 않은 object까지 영향을 끼치는 부분을 수정했습니다.

qoEnums.h
1.  Monster Layer를 추가했습니다.
2.  테스트용으로 추후 삭제하겠습니다.

qoTransform.h
1. camera의 영향을 받는지 않는지에 대해 알 수 있는 멤버 변수 mbAffectedCamera를 추가했습니다.
2. mbAffectedCamera에 접근할 수 있는 접근 함수 void SetAffectedCamera 멤버함수를 추가했습니다.

qoTransform.cpp
1. mbAffectedCamera에 따라 camera::caculate 함수 실행 여부를 판단하게 두었습니다.

qoEntanglementBullet.cpp
1. 첫번째로 맞은 적

qoEntanglementBullet.h
1. bullet에 첫번째로 맞은 적을 저장해둘 first 멤버 변수를 추가했습니다.(추후 이름 변경 예정)
2. bullet이 튕길지 아닐지 결정하는 mIsEntangle 멤버 변수를 추가했습니다.
3.  first 멤버 변수에 접근할 수 있는 접근 함수 SetFirst를 추가했습니다.(추후 이름 변경 예정)
4.  mIsEntangle 멤버 변수에 접근할 수 있는 접근 함SetEntangle를 추가했습니다.

qoHPUIScript.h
qoHPUIScript.cpp
추후 변경 예정

Result
1. 이제 카메라를 통해 흔들리는 효과를 줄 수 있습니다!
- 사용 방법은 ShakeCam(흔들릴 시간,흔들릴 방향,흔들릴 거리, 흔들리는 스피드)을 적용할 구간에 쓰시면 됩니다!
2. Collider가 적용되어 있지 않던 물체도 forceexit가 적용되어 버그가 발생하던 것을 수정했습니다. 그리고 == 문법 실수도 수정했습니다!
3.  이제 카메라 영향을 받을지 아닐지에 대해 transform component를 통해 설정할 수 있습니다!
4.  연쇄 총알 기능을 추가했습니다. 추 후 버그 수정 예정
5.  HPUI를 추가했습니다. 기준 좌표에 대해 테스트를 위해 고정 좌표로 두어서 추후 수정 예정