### PR TITLE
feat : Elevator 기능 보강 추가

### DIFF
--- a/Engine_Windows/qoElevator.cpp
+++ b/Engine_Windows/qoElevator.cpp
@@ -17,6 +17,7 @@ namespace qo
 		, mMovementRange(100)
 		, mTick(true)
 		, mTimer(2.0f)
+		, mHorizontalMovement(0.f)
 	{
 	}
 
@@ -64,7 +65,8 @@ namespace qo
 			{
 				if (mTick)
 				{
-					ElevatorPosition.x += (1.0f / static_cast<float>(application.GetWidth())) * mMovementRange * Time::DeltaTime();
+					mHorizontalMovement = (1.0f / static_cast<float>(application.GetWidth())) * mMovementRange * Time::DeltaTime();
+					ElevatorPosition.x += mHorizontalMovement;
 					mTimer -= Time::DeltaTime();
 					if (mTimer < 0.0f)
 					{
@@ -142,7 +144,7 @@ namespace qo
 				{
 					// 벽 상단 충돌
 					Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
-					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f), 0);
+					PlayerTransform->SetPosition(PlayerPosition.x + mHorizontalMovement, (WallTop + PlayerCollider->GetScale().y / 2.f) - 0.03f, 0);
 					PlayerRigidbody->SetGround(true);
 				}
 			}
@@ -204,7 +206,7 @@ namespace qo
 				{
 					// 벽 상단 충돌
 					Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
-					PlayerTransform->SetPosition(PlayerPosition.x, (WallTop + PlayerCollider->GetScale().y / 2.f), 0);
+					PlayerTransform->SetPosition(PlayerPosition.x + mHorizontalMovement, (WallTop + PlayerCollider->GetScale().y / 2.f) - 0.03f, 0);
 					PlayerRigidbody->SetGround(true);
 				}
 			}
@@ -213,6 +215,13 @@ namespace qo
 
 	void Elevator::OnCollisionExit(Collider* other)
 	{
+		Player* player = dynamic_cast<Player*>(other->GetOwner());
+
+		if (player != nullptr)
+		{
+			Rigidbody* PlayerRigidbody = player->GetComponent<Rigidbody>();
+			PlayerRigidbody->SetGround(false);
+		}
 	}
 
 	void Elevator::ResetTimer()

--- a/Engine_Windows/qoElevator.h
+++ b/Engine_Windows/qoElevator.h
@@ -55,5 +55,8 @@ namespace qo
 		float mInitialTimerValue;
 
 		bool mTick;
+
+
+		float mHorizontalMovement;
 	};
 }

--- a/Engine_Windows/qoLoadScene.h
+++ b/Engine_Windows/qoLoadScene.h
@@ -12,6 +12,6 @@ namespace qo
 		SceneManager::CreateScene<Stage1_1>(L"Stage1_1");
 		SceneManager::CreateScene<Stage1_2>(L"Stage1_2");
 
-		SceneManager::LoadScene(L"PlayScene");
+		SceneManager::LoadScene(L"Stage1_2");
 	}
 }

--- a/Engine_Windows/qoStage1_2.cpp
+++ b/Engine_Windows/qoStage1_2.cpp
@@ -285,7 +285,8 @@ namespace qo
 		EventElevator[1]->SetRange(384);
 		EventElevator[2]->SetRange(384);
 		EventElevator[3]->SetRange(640);
-		EventElevator[4]->SetRange(2816);
+		//EventElevator[4]->SetRange(2816);
+		EventElevator[4]->SetRange(512);
 		EventElevator[5]->SetRange(512);
 
 		// 개체 생성


### PR DESCRIPTION
Elevator 가 내려가면 플레이어가 공중에 떠잇는 버그 수정 - Collider 충돌시 플레이어와 Elevator 를 0.03f 만큼 붙어있게 설정하고 Exit시 SetGround 해제

Elevator X축 이동시 플레이어도 같이 이동하도록 변경 - mHorizontalMovement 멤버변수로 이번 프레임에 X축으로 이동한 량만큼 플레이어 x축 위치에 더해주도록 추가