### PR TITLE
feat : Trigger 작동전에 몬스터가 죽어있는 상태면 프로그램 터지는 버그 수정

### DIFF
--- a/Engine_Windows/qoTrigger.cpp
+++ b/Engine_Windows/qoTrigger.cpp
@@ -24,6 +24,21 @@ namespace qo
 	void Trigger::Update()
 	{
 		GameObject::Update();
+
+		// Dead Object Á¦¿Ü
+		std::vector<GameObject*>::iterator iter = mEnemies.begin();
+
+		for (; iter != mEnemies.end();)
+		{
+			if ((*iter)->GetGameObjectState() == GameObject::eState::Dead)
+			{
+				iter = mEnemies.erase(iter);
+			}
+			else
+			{
+				iter++;
+			}
+		}
 	}
 
 	void Trigger::LateUpdate()
@@ -50,7 +65,7 @@ namespace qo
 		{
 			for (size_t i = 0; i < mEnemies.size(); i++)
 			{
-				if (mEnemies[i] != nullptr)
+				if (mEnemies[i] != nullptr && mEnemies[i]->GetGameObjectState() != eState::Dead)
 					mEnemies[i]->GetComponent<Rigidbody>()->SetActive(true);
 			}
 		}


### PR DESCRIPTION
매프레임마다 mEnemise의 상태를 확인하여  Dead 상태면 제외하도록 추가